### PR TITLE
DSR-19: switch back to contentful JSON tokens

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,10 +1,12 @@
+const api = require('./.contentful.json');
+
 module.exports = {
   //
   // Environment variables
   //
   env: {
-    CTF_SPACE_ID: process.env.CTF_SPACE_ID,
-    CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
+    CTF_SPACE_ID: api.CTF_SPACE_ID,
+    CTF_CDA_ACCESS_TOKEN: api.CTF_CDA_ACCESS_TOKEN,
   },
   //
   // Global <head> metadata


### PR DESCRIPTION
After some discussion we decided it will be better to use a file to store secrets, so that it's available to docker when both building the image and running the container.

@teodorescuserban please give this a look and confirm it's properly implementing what you proposed.