### PR TITLE
DSR-39: WIP for PNG Snaps

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="card card--article article clearfix">
+  <article class="card card--article article clearfix" :id="'cf-' + content.sys.id">
     <span class="card__title">{{ content.fields.sectionHeading }}</span>
     <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__text md">

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,15 +1,15 @@
 <template>
   <article class="card card--article article clearfix">
-    <span class="card__title">{{ article.fields.sectionHeading }}</span>
-    <div class="article__content" v-bind:class="{ 'article__content--has-image': article.fields.image }">
+    <span class="card__title">{{ content.fields.sectionHeading }}</span>
+    <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__text md">
-        <h3 class="article__title">{{ article.fields.title }}</h3>
-        <div v-html="$md.render(article.fields.article)"></div>
+        <h3 class="article__title">{{ content.fields.title }}</h3>
+        <div v-html="$md.render(content.fields.article)"></div>
       </div>
-      <div class="article__image" v-if="article.fields.image">
+      <div class="article__image" v-if="content.fields.image">
         <figure>
-          <img :src="article.fields.image.fields.file.url" :alt="article.fields.image.fields.title">
-          <figcaption v-if="article.fields.image.fields.description">{{ article.fields.image.fields.description }}</figcaption>
+          <img :src="content.fields.image.fields.file.url" :alt="content.fields.image.fields.title">
+          <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
         </figure>
       </div>
     </div>
@@ -17,8 +17,10 @@
 </template>
 
 <script>
+  import Card from './Card.vue';
   export default {
-    props: ['article'],
+    extends: Card,
+    props: ['content'],
 
     beforeCreate: function () {
       // Automatically open all links within Markdown content in a new tab. We

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,26 +1,24 @@
 <template>
-  <div>
-    <article :key="article.sys.id" v-for="article in articles"  class="card card--article article clearfix">
-      <span class="card__title">{{ article.fields.sectionHeading }}</span>
-      <div class="article__content" v-bind:class="{ 'article__content--has-image': article.fields.image }">
-        <div class="article__text md">
-          <h3 class="article__title">{{ article.fields.title }}</h3>
-          <div v-html="$md.render(article.fields.article)"></div>
-        </div>
-        <div class="article__image" v-if="article.fields.image">
-          <figure>
-            <img :src="article.fields.image.fields.file.url" :alt="article.fields.image.fields.title">
-            <figcaption v-if="article.fields.image.fields.description">{{ article.fields.image.fields.description }}</figcaption>
-          </figure>
-        </div>
+  <article class="card card--article article clearfix">
+    <span class="card__title">{{ article.fields.sectionHeading }}</span>
+    <div class="article__content" v-bind:class="{ 'article__content--has-image': article.fields.image }">
+      <div class="article__text md">
+        <h3 class="article__title">{{ article.fields.title }}</h3>
+        <div v-html="$md.render(article.fields.article)"></div>
       </div>
-    </article>
-  </div>
+      <div class="article__image" v-if="article.fields.image">
+        <figure>
+          <img :src="article.fields.image.fields.file.url" :alt="article.fields.image.fields.title">
+          <figcaption v-if="article.fields.image.fields.description">{{ article.fields.image.fields.description }}</figcaption>
+        </figure>
+      </div>
+    </div>
+  </article>
 </template>
 
 <script>
   export default {
-    props: ['articles'],
+    props: ['article'],
 
     beforeCreate: function () {
       // Automatically open all links within Markdown content in a new tab. We

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,5 +1,6 @@
 <template>
-  <article class="card card--article article clearfix" :id="'cf-' + content.sys.id">
+  <article class="card card--article article clearfix" :id="this.cssId">
+    <CardActions :frag="'#' + this.cssId" />
     <span class="card__title">{{ content.fields.sectionHeading }}</span>
     <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__text md">
@@ -21,6 +22,11 @@
   export default {
     extends: Card,
     props: ['content'],
+    computed: {
+      cssId: function() {
+        return 'cf-' + this.content.sys.id;
+      }
+    },
 
     beforeCreate: function () {
       // Automatically open all links within Markdown content in a new tab. We

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,6 +1,5 @@
 <template>
   <article class="card card--article article clearfix" :id="this.cssId">
-    <CardActions :frag="'#' + this.cssId" />
     <span class="card__title">{{ content.fields.sectionHeading }}</span>
     <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__text md">
@@ -14,6 +13,7 @@
         </figure>
       </div>
     </div>
+    <CardActions :frag="'#' + this.cssId" />
   </article>
 </template>
 

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -18,7 +18,7 @@
   }
 </script>
 
-<style lang="scss">
+<style lang="scss">// NOT scoped, we want styles to "extend" to children
   .card {
     margin: 0;
     margin-bottom: 1rem;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -5,16 +5,12 @@
 </template>
 
 <script>
+  import CardActions from './CardActions.vue';
   export default {
+    components: {
+      CardActions,
+    },
     props: ['content'],
-    methods: {
-      getSnap: function () {
-        console.log('getSnap()');
-      },
-      handleSnap: function() {
-        console.log('handleSnap()');
-      }
-    }
   }
 </script>
 
@@ -26,7 +22,7 @@
     background: white;
     border-radius: 7px;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
-    position: relative;
+    position: relative; // for CardActions
   }
 
   .card__title {
@@ -41,36 +37,4 @@
       font-family: "Roboto Condensed", sans-serif;
     }
   }
-
-  .card__actions {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-  }
-
-  .card__actions .btn {
-    width: 1rem;
-    height: 1rem;
-    border: 0;
-    margin: 0;
-    margin-left: .5rem;
-    opacity: 1;
-    transition: opacity .3333s ease-out;
-  }
-
-  .card__actions .btn:hover {
-    opacity: .8;
-    transition: opacity .1666s ease-out;
-  }
-
-  .btn--download {
-    background: url('/icons/icon--download.svg') center no-repeat;
-    background-size: contain;
-  }
-
-  .btn--share {
-    background: url('/icons/icon--share.svg') center no-repeat;
-    background-size: contain;
-  }
-
 </style>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: ['content'],
+    methods: {
+      getSnap: function () {
+        console.log('getSnap()');
+      },
+      handleSnap: function() {
+        console.log('handleSnap()');
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  .card {
+    margin: 0;
+    margin-bottom: 1rem;
+    padding: 1rem;
+    background: white;
+    border-radius: 7px;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
+    position: relative;
+  }
+
+  .card__title {
+    margin-bottom: 1rem;
+    color: #444;
+    font-family: sans-serif;
+    font-weight: 700;
+    font-size: 17px;
+    text-transform: uppercase;
+
+    .wf-loaded & {
+      font-family: "Roboto Condensed", sans-serif;
+    }
+  }
+
+  .card__actions {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+  }
+
+  .card__actions .btn {
+    width: 1rem;
+    height: 1rem;
+    border: 0;
+    margin: 0;
+    margin-left: .5rem;
+    opacity: 1;
+    transition: opacity .3333s ease-out;
+  }
+
+  .card__actions .btn:hover {
+    opacity: .8;
+    transition: opacity .1666s ease-out;
+  }
+
+  .btn--download {
+    background: url('/icons/icon--download.svg') center no-repeat;
+    background-size: contain;
+  }
+
+  .btn--share {
+    background: url('/icons/icon--share.svg') center no-repeat;
+    background-size: contain;
+  }
+
+</style>

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="actions">
+    <button class="btn btn--download" @click="requestSnap"></button>
+  </div>
+</template>
+
+<script>
+  import axios from 'axios';
+  export default {
+    props: ['frag'],
+    methods: {
+      requestSnap: function() {
+        const sitRepUrl = window.location.href;
+        const snapEndpoint = 'http://localhost:8442/snap/';
+        const snapRequest = `${snapEndpoint}?url=${encodeURIComponent(sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&frag=${encodeURIComponent(this.frag)}`;
+
+        axios
+          .post(snapRequest)
+          .then(console.log('😃🤳 Snap requested...', snapRequest));
+      },
+      handleSnap: function() {
+        console.log('📸 handling Snap...');
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .actions {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+  }
+
+  .actions .btn {
+    width: 1rem;
+    height: 1rem;
+    border: 0;
+    margin: 0;
+    margin-left: .5rem;
+    opacity: 1;
+    transition: opacity .3333s ease-out;
+  }
+
+  .actions .btn:hover {
+    opacity: .8;
+    transition: opacity .1666s ease-out;
+  }
+
+  .actions .btn:focus {
+    animation: clicked .1666s ease-in;
+    animation-fill-mode: forwards;
+  }
+
+  .btn--download {
+    background: url('/icons/icon--download.svg') center no-repeat;
+    background-size: contain;
+  }
+
+  .btn--share {
+    background: url('/icons/icon--share.svg') center no-repeat;
+    background-size: contain;
+  }
+
+  @keyframes clicked {
+    from {
+      transform: translate(0) scale(1);
+      opacity: .8;
+    }
+    to {
+      transform: translateZ(300px) scale(5);
+      opacity: 0;
+    }
+  }
+</style>

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="actions" v-show="!snapInProgress">
-    <button class="btn btn--download" @click="requestSnap"></button>
+    <button class="btn btn--download" @click="requestSnap"><span class="element-invisible">Save as PNG</span></button>
   </div>
 </template>
 

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="actions">
+  <div class="actions" v-show="!snapInProgress">
     <button class="btn btn--download" @click="requestSnap"></button>
   </div>
 </template>
@@ -8,17 +8,29 @@
   import axios from 'axios';
   export default {
     props: ['frag'],
+    data() {
+      return {
+        snapInProgress: false,
+      };
+    },
     methods: {
       requestSnap: function() {
         const sitRepUrl = window.location.href;
         const snapEndpoint = 'http://localhost:8442/snap/';
         const snapRequest = `${snapEndpoint}?url=${encodeURIComponent(sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&frag=${encodeURIComponent(this.frag)}`;
 
+        setTimeout(() => {this.snapInProgress = true;}, 166); // 166ms to allow CSS transition to finish
+        console.log('😃🤳 Snap requested...', snapRequest);
+
         axios
           .post(snapRequest)
-          .then(console.log('😃🤳 Snap requested...', snapRequest));
+          .then((response) => {
+            this.handleSnap(response);
+          });
       },
-      handleSnap: function() {
+      handleSnap: function(response) {
+        this.snapInProgress = false;
+
         console.log('📸 handling Snap...');
       }
     }

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="actions" v-show="!snapInProgress">
+  <div class="actions" v-show="false/*!snapInProgress*/">
     <button class="btn btn--download" @click="requestSnap"><span class="element-invisible">Save as PNG</span></button>
   </div>
 </template>

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -17,7 +17,7 @@
       requestSnap: function() {
         const sitRepUrl = window.location.href;
         const snapEndpoint = 'http://localhost:8442/snap/';
-        const snapRequest = `${snapEndpoint}?url=${encodeURIComponent(sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&frag=${encodeURIComponent(this.frag)}`;
+        const snapRequest = `${snapEndpoint}?url=${encodeURIComponent(sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.frag)}`;
 
         setTimeout(() => {this.snapInProgress = true;}, 166); // 166ms to allow CSS transition to finish
         console.log('😃🤳 Snap requested...', snapRequest);

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="card card--contacts">
     <h3 class="card__title">Contacts</h3>
-    <address :key="contact.sys.id" v-for="contact in contacts" class="card__contact contact">
+    <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
       <span class="job-title">{{ contact.fields.jobTitle }}</span><br>
       <a class="email" :href="'mailto:' + contact.fields.email">{{ contact.fields.email }}</a>
@@ -11,8 +11,10 @@
 </template>
 
 <script>
+  import Card from './Card.vue';
   export default {
-    props: ['contacts']
+    extends: Card,
+    props: ['content'],
   }
 </script>
 

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="card card--contacts">
+  <section class="card card--contacts" :id="'cf-' + this.uid">
     <h3 class="card__title">Contacts</h3>
     <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
@@ -15,6 +15,11 @@
   export default {
     extends: Card,
     props: ['content'],
+    computed: {
+      uid: function () {
+        return this.content.map((item) => item.sys.id).join('_');
+      }
+    }
   }
 </script>
 

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -18,7 +18,7 @@
   }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .contact {
     font-style: normal;
   }

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="card card--contacts" :id="'cf-' + this.uid">
+  <section class="card card--contacts">
     <h3 class="card__title">Contacts</h3>
     <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
@@ -15,11 +15,6 @@
   export default {
     extends: Card,
     props: ['content'],
-    computed: {
-      uid: function () {
-        return this.content.map((item) => item.sys.id).join('_');
-      }
-    }
   }
 </script>
 

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -1,6 +1,5 @@
 <template>
   <section class="card card--keyFigures" :id="this.cssId">
-    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Figures</h2>
     <div class="figures clearfix">
       <figure v-for="figure in content">
@@ -8,6 +7,7 @@
         <figcaption>{{ figure.fields.caption }}</figcaption>
       </figure>
     </div>
+    <CardActions :frag="'#' + this.cssId" />
   </section>
 </template>
 

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -28,7 +28,6 @@
   @supports (display: grid) {
     .figures {
       display: grid;
-      /*grid-template-rows: 1fr 1fr;*/
       grid-template-columns: 1fr 1fr;
       grid-gap: 1rem;
     }
@@ -50,6 +49,7 @@
       font-family: "Roboto Condensed", sans-serif;
     }
   }
+
   figcaption {
     font-size: .8em;
     color: #A7A9AC;

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -11,8 +11,10 @@
 </template>
 
 <script>
+  import Card from './Card.vue';
   export default {
-    props: ['content']
+    extends: Card,
+    props: ['content'],
   }
 </script>
 

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -1,5 +1,6 @@
 <template>
-  <section class="card card--keyFigures" :id="'cf-' + this.uid">
+  <section class="card card--keyFigures" :id="this.cssId">
+    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Figures</h2>
     <div class="figures clearfix">
       <figure v-for="figure in content">
@@ -16,8 +17,8 @@
     extends: Card,
     props: ['content'],
     computed: {
-      uid: function () {
-        return this.content.map((item) => item.sys.id).join('_');
+      cssId: function () {
+        return 'cf-' + this.content.map((item) => item.sys.id).join('_');
       }
     }
   }

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="card card--keyFigures">
+  <section class="card card--keyFigures" :id="'cf-' + this.uid">
     <h2 class="card__title">Key Figures</h2>
     <div class="figures clearfix">
       <figure v-for="figure in content">
@@ -15,6 +15,11 @@
   export default {
     extends: Card,
     props: ['content'],
+    computed: {
+      uid: function () {
+        return this.content.map((item) => item.sys.id).join('_');
+      }
+    }
   }
 </script>
 

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="card card--keyFinancials" :id="this.cssId">
-    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Financials</h2>
     <p>Data TBD as we pull from FTS</p>
     <p v-if="content">content: {{ content }}</p>
+    <CardActions :frag="'#' + this.cssId" />
   </section>
 </template>
 

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -1,5 +1,6 @@
 <template>
-  <section class="card card--keyFinancials" :id="'cf-' + this.uid">
+  <section class="card card--keyFinancials" :id="this.cssId">
+    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Financials</h2>
     <p>Data TBD as we pull from FTS</p>
     <p v-if="content">content: {{ content }}</p>
@@ -12,8 +13,8 @@
     extends: Card,
     props: ['content'],
     computed: {
-      uid: function () {
-        return 'TBD_keyFinancials_unique_id';
+    cssId: function () {
+        return 'cf-' + 'TBD_keyFinancials_unique_id';
       }
     }
   }

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -14,4 +14,4 @@
   }
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped></style>

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="card card--keyFinancials">
+  <section class="card card--keyFinancials" :id="'cf-' + this.uid">
     <h2 class="card__title">Key Financials</h2>
     <p>Data TBD as we pull from FTS</p>
     <p v-if="content">content: {{ content }}</p>
@@ -11,6 +11,11 @@
   export default {
     extends: Card,
     props: ['content'],
+    computed: {
+      uid: function () {
+        return 'TBD_keyFinancials_unique_id';
+      }
+    }
   }
 </script>
 

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -2,11 +2,15 @@
   <section class="card card--keyFinancials">
     <h2 class="card__title">Key Financials</h2>
     <p>Data TBD as we pull from FTS</p>
+    <p v-if="content">content: {{ content }}</p>
   </section>
 </template>
 
 <script>
+  import Card from './Card.vue';
   export default {
+    extends: Card,
+    props: ['content'],
   }
 </script>
 

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -21,7 +21,7 @@
   }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 
 .image {
   width: 100%;

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="card card--keyMessageSection key-messages">
+  <article class="card card--keyMessages key-messages">
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,5 +1,6 @@
 <template>
-  <article class="card card--keyMessages key-messages" :id="'cf-' + content.sys.id">
+  <article class="card card--keyMessages key-messages" :id="this.cssId">
+    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">
@@ -18,6 +19,11 @@
   export default {
     extends: Card,
     props: ['content'],
+    computed: {
+      cssId: function () {
+        return 'cf-' + this.content.sys.id;
+      }
+    }
   }
 </script>
 

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,6 +1,5 @@
 <template>
   <article class="card card--keyMessages key-messages" :id="this.cssId">
-    <CardActions :frag="'#' + this.cssId" />
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">
@@ -11,6 +10,7 @@
       </ul>
       <img class="image" :src="content.fields.keyMessageMainImage.fields.file.url" :alt="content.fields.keyMessageMainImage.fields.description">
     </div>
+    <CardActions :frag="'#' + this.cssId" />
   </article>
 </template>
 

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="card card--keyMessages key-messages">
+  <article class="card card--keyMessages key-messages" :id="'cf-' + content.sys.id">
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -14,8 +14,10 @@
 </template>
 
 <script>
+  import Card from './Card.vue';
   export default {
-    props: ['content']
+    extends: Card,
+    props: ['content'],
   }
 </script>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,9 +1,6 @@
 <template>
-  <div>
-    <nuxt/>
-  </div>
+  <nuxt/>
 </template>
 
 <style>
 </style>
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -2574,6 +2574,15 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@nuxtjs/markdownit": "^1.2.2",
     "@nuxtjs/moment": "^1.0.0",
     "ajv": "^6.5.4",
+    "axios": "^0.18.0",
     "contentful": "^7.0.4",
     "fontfaceobserver": "^2.0.13",
     "moment": "^2.22.2",

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -12,7 +12,7 @@
       </section>
 
       <section class="section--everythingElse">
-        <Article :key="article.sys.id" :content="article" v-for="article in entry.fields.article" />
+        <Article :content="article" v-for="article in entry.fields.article" :key="article.sys.id" />
       </section>
     </main>
 

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -12,7 +12,7 @@
       </section>
 
       <section class="section--everythingElse">
-        <Articles :articles="entry.fields.article" />
+        <Article :key="article.sys.id" :article="article" v-for="article in entry.fields.article" />
       </section>
     </main>
 
@@ -24,7 +24,7 @@
   import AppBar from '~/components/AppBar';
   import AppFooter from '~/components/AppFooter';
   import AppHeader from '~/components/AppHeader';
-  import Articles from '~/components/Articles';
+  import Article from '~/components/Article';
   import Contacts from '~/components/Contacts';
   import KeyFigures from '~/components/KeyFigures';
   import KeyFinancials from '~/components/KeyFinancials';
@@ -40,7 +40,7 @@
       AppBar,
       AppFooter,
       AppHeader,
-      Articles,
+      Article,
       Contacts,
       KeyFigures,
       KeyFinancials,

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -7,12 +7,12 @@
       <section class="section--primary clearfix">
         <KeyMessages :content="entry.fields.keyMessageSection" />
         <KeyFigures :content="entry.fields.keyFigure" />
-        <KeyFinancials />
-        <Contacts :contacts="entry.fields.contacts" />
+        <KeyFinancials :content="false" />
+        <Contacts :content="entry.fields.contacts" />
       </section>
 
       <section class="section--everythingElse">
-        <Article :key="article.sys.id" :article="article" v-for="article in entry.fields.article" />
+        <Article :key="article.sys.id" :content="article" v-for="article in entry.fields.article" />
       </section>
     </main>
 

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -77,7 +77,7 @@
 
 @media (min-width: 900px) {
 
-  .card--keyMessageSection {
+  .card--keyMessages {
     float: left;
     width: 73%;
     width: calc(75% - 1rem);
@@ -92,7 +92,7 @@
     width: calc(25%);
     margin-bottom: 1rem;
 
-    /* This group of three cards must resolve to height of keyMessageSection */
+    /* This group of three cards must resolve to height of keyMessages */
     height: calc(30vh - .666rem);
   }
 
@@ -102,7 +102,6 @@
       grid-template-areas: "keyMessages keyFigures"
                            "keyMessages keyFinancials"
                            "keyMessages contacts";
-      /*grid-template-rows: repeat(3, 1fr);*/
       grid-template-columns: 3fr 1fr;
       grid-gap: 1rem;
       margin-bottom: 1rem;
@@ -118,7 +117,7 @@
     }
 
     /* Drop selected cards into their homes */
-    .card--keyMessageSection {
+    .card--keyMessages {
       grid-area: keyMessages;
     }
     .card--keyFigures {

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :id="'cf-' + entry.sys.id">
     <AppBar />
     <AppHeader :title="entry.fields.title" :updated="entry.fields.dateUpdated" />
 

--- a/static/global.css
+++ b/static/global.css
@@ -207,61 +207,6 @@ main code {
   border-radius: 3px;
 }
 
-/*—— Cards ———————————————————————————————————————————————————————————————————*/
-
-.card {
-  margin: 0;
-  margin-bottom: 1rem;
-  padding: 1rem;
-  background: white;
-  border-radius: 7px;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
-  position: relative;
-}
-
-.card__title {
-  margin-bottom: 1rem;
-  color: #444;
-  font-family: sans-serif;
-  font-weight: 700;
-  font-size: 17px;
-  text-transform: uppercase;
-}
-.wf-loaded .card__title {
-  font-family: "Roboto Condensed", sans-serif;
-}
-
-.card__actions {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-}
-
-.card__actions .btn {
-  width: 1rem;
-  height: 1rem;
-  border: 0;
-  margin: 0;
-  margin-left: .5rem;
-  opacity: 1;
-  transition: opacity .3333s ease-out;
-}
-
-.card__actions .btn:hover {
-  opacity: .8;
-  transition: opacity .1666s ease-out;
-}
-
-.btn--download {
-  background: url('/icons/icon--download.svg') center no-repeat;
-  background-size: contain;
-}
-
-.btn--share {
-  background: url('/icons/icon--share.svg') center no-repeat;
-  background-size: contain;
-}
-
 
 /*—— Markdown ————————————————————————————————————————————————————————————————*/
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-39

I did some important but disruptive reorganization when building PNG functionality. It is blocking my progress in other smaller tickets so I'm merging this WIP in order to continue on other tasks. The buttons themselves are visually hidden from view so merging this PR will not create any broken UI elements on the staging site.

- `Articles.vue` -> `Article.vue` (turned its output into a single card, and moved the loop to the page logic where the content is requested)
- Introduced `CardActions.vue` to encapsulate the actions that can be taken on an individual card (Save as PNG, Share, etc)
- sorta-kinda-works with Snap Service (on my local, :trollface:)