### PR TITLE
DSR-42: match print design

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -112,16 +112,16 @@
   @media screen and (min-width: 900px) {
     // Default styles are float-based. This covers a wide range of old browsers.
     .article__content--has-image {
+      .article__image {
+        float: right;
+        width: 33.333%;
+      }
+
       .article__text {
         float: left;
         clear: left;
         width: calc(66.666% - 1rem);
         margin-right: 1rem;
-      }
-
-      .article__image {
-        float: left;
-        width: 33.333%;
       }
     }
 

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -2,15 +2,15 @@
   <article class="card card--article article clearfix" :id="this.cssId">
     <span class="card__title">{{ content.fields.sectionHeading }}</span>
     <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
-      <div class="article__text md">
-        <h3 class="article__title">{{ content.fields.title }}</h3>
-        <div v-html="$md.render(content.fields.article)"></div>
-      </div>
       <div class="article__image" v-if="content.fields.image">
         <figure>
           <img :src="content.fields.image.fields.file.url" :alt="content.fields.image.fields.title">
           <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
         </figure>
+      </div>
+      <div class="article__text md">
+        <h3 class="article__title">{{ content.fields.title }}</h3>
+        <div v-html="$md.render(content.fields.article)"></div>
       </div>
     </div>
     <CardActions :frag="'#' + this.cssId" />
@@ -105,6 +105,10 @@
     }
   }
 
+  .article__image {
+    margin-bottom: 1rem;
+  }
+
   @media screen and (min-width: 900px) {
     // Default styles are float-based. This covers a wide range of old browsers.
     .article__content--has-image {
@@ -127,7 +131,7 @@
         display: grid;
         grid-template-areas: 'articleText articleImages';
         grid-template-rows: 1fr;
-        grid-template-columns: 2fr 1fr;
+        grid-template-columns: 6fr 4fr;
         grid-gap: 1rem;
 
         .article__text,
@@ -169,7 +173,7 @@
     @media screen {
       position: absolute;
       right: 0;
-      bottom: 3px;
+      bottom: 4px;
       max-width: 80%;
       padding: .666em 1.333em;
       background: rgba(0,0,0,0.666);
@@ -238,4 +242,12 @@
     }
 
   } // @media screen
+
+  @media print {
+    .article__image {
+      float: right;
+      max-width: 40%;
+      margin-left: 2em;
+    }
+  }
 </style>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -42,7 +42,8 @@
     .card {
       box-shadow: none;
       border-radius: 0;
-      border-bottom: 3px solid #4c8cca;
+      border-bottom: 1px solid #ddd;
+      padding: 0 1rem;
       padding-bottom: 2rem;
     }
   }

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -35,5 +35,8 @@
     .card {
       page-break-inside: avoid;
     }
+    .job-title {
+      color: #666;
+    }
   }
 </style>

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -65,5 +65,11 @@
     .card {
       page-break-inside: avoid;
     }
+    .data {
+      color: inherit;
+    }
+    figcaption {
+      color: #67696C;
+    }
   }
 </style>

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -60,7 +60,7 @@
       display: grid;
       grid-template-areas: "km-messages km-image";
       grid-template-rows: 1fr;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 1fr 2fr;
       grid-gap: 1rem;
     }
 
@@ -71,16 +71,22 @@
     }
 
     .message-list {
-      grid-area: "km-messages";
+      grid-area: km-messages;
     }
 
     .image {
-      grid-area: "km-image";
+      grid-area: km-image;
     }
 
     .key-messages__area::after {
       content: none;
     }
+  }
+} /* print, screen and (min-width: 800px) */
+
+@media print {
+  .message {
+    font-size: 1em;
   }
 }
 </style>

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -183,5 +183,32 @@
     }
   } /* @supports (display: grid) */
 } /* @media print and (min-width: 15cm), screen and (min-width: 1164px) */
+
+/*—— Print styles ————————————————————————————————————————————————————————————*/
+@media print {
+  body {
+    font-size: 12pt;
+  }
+
+  .section--primary {
+    border-bottom: 1px solid #ddd;
+  }
+
+  .card--keyMessages {
+    border-right: 1px solid #ddd;
+    border-bottom: 0;
+    padding: 0;
+    font-size: 1em;
+  }
+  .card--keyFigures {
+    border-bottom: 1px solid #ddd;
+  }
+  .card--keyFinancials {
+    border-bottom: 1px solid #ddd;
+  }
+  .card--contacts {
+    border-bottom: 0;
+  }
+}
 </style>
 

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -73,9 +73,9 @@
 
 <style>
 
-/*—— Report Medium/Print layout ——————————————————————————————————————————————*/
+/*—— Report Medium layout ——————————————————————————————————————————————*/
 
-@media print and (min-width: 15cm), screen and (min-width: 900px) {
+@media screen and (min-width: 760px) {
   @supports (display: grid) {
     .section--primary {
       display: grid;
@@ -104,11 +104,12 @@
       grid-area: contacts;
     }
   } /* @supports (display: grid) */
-} /* @media print, screen and (min-width: 900px) */
+} /* @media screen and (min-width: 760px) */
 
-/*—— Report Large layout —————————————————————————————————————————————————————*/
+/*—— Report Large/Print layout —————————————————————————————————————————————————————*/
 
-@media screen and (min-width: 1164px) {
+@media print and (min-width: 15cm),
+       screen and (min-width: 1164px) {
   /**
    * No CSS Grid support
    *
@@ -181,6 +182,6 @@
       margin-bottom: 1rem;
     }
   } /* @supports (display: grid) */
-} /* @media (min-width: 1164px) */
+} /* @media print and (min-width: 15cm), screen and (min-width: 1164px) */
 </style>
 

--- a/static/global.css
+++ b/static/global.css
@@ -228,6 +228,11 @@ main code {
 @media print {
   body {
     background-color: white;
+    font-size: 10pt !important;
+  }
+
+  main ul {
+    padding: 0 0 0 1em;
   }
 
   .md a[href]::after {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-42

After soliciting feedback on yesterday's work, I was pointed to a pre-existing design that I didn't know about. This PR brings us much closer to the design.

- reduced font-size means much more content fits on A4 sheets
- got rid of my thick blue lines in favor of thinner, lighter lines to demarcate cards
- changed content order to place Article images before text. Text flows beneath them on print.
- Figures/Financials use black instead of blue for main numbers
- tweaked various layouts to get everything looking good on all the viewports/print

### Testing

- Win10 / IE11
- Win10 / Edge17
- macOS / Safari 10.13.6
- macOS / Chrome 69
- macOS / FF 62
- Android 8.1 / Chrome 69
- iOS 11.3 iPad / Safari
- iOS 12.0 iPhone 6 / Safari
- my local Snap Service

Sample PDF from Snap: [DSR-42-print-design1.pdf](https://github.com/UN-OCHA/reports-site/files/2491698/DSR-42-print-design1.pdf)
