### PR TITLE
DSR-1: install Google Tag Manager

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,6 +37,7 @@ module.exports = {
   modules: [
     '@nuxtjs/markdownit',
     ['@nuxtjs/moment', ['fr']],
+    ['@nuxtjs/google-tag-manager', { id: 'GTM-W4PXQBG' }],
   ],
   markdownit: {
     injected: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,6 +1999,11 @@
         }
       }
     },
+    "@nuxtjs/google-tag-manager": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/google-tag-manager/-/google-tag-manager-2.1.0.tgz",
+      "integrity": "sha512-NmEqiidNC/sPjizURKT8fMIe41Q/R2egIFICeOfNcCqZfxJjHttUjQaYMJ+ef7bn50N724tCain+vQocUZjliw=="
+    },
     "@nuxtjs/markdownit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@nuxtjs/markdownit/-/markdownit-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
+    "@nuxtjs/google-tag-manager": "^2.1.0",
     "@nuxtjs/markdownit": "^1.2.2",
     "@nuxtjs/moment": "^1.0.0",
     "ajv": "^6.5.4",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-1

Installs GTM on production. The Nuxt module claims to detect `NODE_ENV` and avoids tracking non-production environments, but when I run `npm run dev` on my local I still see it.

This at least gets us tracking on the live site and we can somehow expunge my dev noise later on.