### PR TITLE
DSR-42: match print design more closely

### DIFF
--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -32,6 +32,29 @@
     cursor: pointer;
   }
 
+  .app-bar .btn--toggle:focus {
+    animation: btn--toggle 1s ease-in-out 1;
+    outline: 0;
+  }
+
+  //
+  // Animation: hamburger toggle
+  //
+  @keyframes btn--toggle {
+    0% {
+      transform: rotate(0deg) scale(1);
+    }
+    6% {
+      transform: rotate(0deg) scale(1.5);
+    }
+    24% {
+      transform: rotate(0deg) scale(1);
+    }
+  }
+
+  //
+  // Tablet+ layout
+  //
   @media (min-width: 600px) {
     .app-bar {
       right: auto;
@@ -45,23 +68,9 @@
     }
   }
 
-  .app-bar .btn--toggle:focus {
-    animation: btn--toggle 1s ease-in-out 1;
-    outline: 0;
-  }
-
-  @keyframes btn--toggle {
-    0% {
-      transform: rotate(0deg) scale(1);
-    }
-    6% {
-      transform: rotate(0deg) scale(1.5);
-    }
-    24% {
-      transform: rotate(0deg) scale(1);
-    }
-  }
-
+  //
+  // Print layout
+  //
   @media print {
     .app-bar {
       display: none;

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -26,6 +26,12 @@
     padding-top: 1em;
     font-size: .85em;
     overflow-x: hidden; // long links shouldn't break layout
+
+    @media print {
+      padding-top: 1rem;
+      font-size: 1em;
+      page-break-inside: avoid;
+    }
   }
 
   .text {
@@ -41,21 +47,18 @@
   .link {
     display: inline-block;
     margin-right: 2em;
+
+    @media print {
+      display: block;
+      margin-bottom: .5em;
+    }
   }
 
   .link a {
-    color: hsl(211, 100%, 65%);
-  }
+    color: #4c8cca;
 
-  @media print {
-    .footer {
-      border-top: 0;
-      padding-top: 0;
-      font-size: 1em;
-      page-break-inside: avoid;
-    }
-    .link {
-      display: block;
+    @media print {
+      text-decoration: none;
     }
   }
 </style>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -23,6 +23,10 @@
   .header[role="banner"] {
     border-bottom: 3px solid #4c8cca;
     padding-bottom: 1rem;
+
+    @media print {
+      margin-bottom: 2rem;
+    }
   }
 
   .logo-link {
@@ -31,6 +35,10 @@
     margin-top: 7px;
     margin-right: 10px;
     border-right: 2px solid #4c8cca;
+
+    @media print {
+      margin-top: 0;
+    }
   }
 
   .logo {
@@ -78,13 +86,5 @@
 
   .last-updated::first-letter {
     text-transform: capitalize;
-  }
-
-  @media print {
-    // Hide the logo because we'll configure the PDF Snaps to include it at the
-    // top of each page when printing.
-    .logo-link {
-      display: none;
-    }
   }
 </style>

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -109,50 +109,6 @@
     margin-bottom: 1rem;
   }
 
-  @media screen and (min-width: 900px) {
-    // Default styles are float-based. This covers a wide range of old browsers.
-    .article__content--has-image {
-      .article__image {
-        float: right;
-        width: 33.333%;
-      }
-
-      .article__text {
-        float: left;
-        clear: left;
-        width: calc(66.666% - 1rem);
-        margin-right: 1rem;
-      }
-    }
-
-    // When CSS Grid support is detected, we rely on that instead.
-    @supports (display: grid) {
-      .article__content--has-image {
-        display: grid;
-        grid-template-areas: 'articleText articleImages';
-        grid-template-rows: 1fr;
-        grid-template-columns: 6fr 4fr;
-        grid-gap: 1rem;
-
-        .article__text,
-        .article__image {
-          float: none;
-          width: auto;
-          margin: 0;
-        }
-      }
-
-      .article__text {
-        grid-area: articleText;
-      }
-
-      .article__image {
-        grid-area: articleImages;
-        width: 100%;
-      }
-    }
-  }
-
   figure {
     position: relative;
 
@@ -188,8 +144,58 @@
     }
   }
 
+  @media screen and (min-width: 900px) {
+    //
+    // Float-based layout
+    //
+    .article__content--has-image {
+      .article__image {
+        float: right;
+        width: 33.333%;
+      }
+
+      .article__text {
+        float: left;
+        clear: left;
+        width: calc(66.666% - 1rem);
+        margin-right: 1rem;
+      }
+    }
+
+    //
+    // CSS Grid layout
+    //
+    @supports (display: grid) {
+      .article__content--has-image {
+        display: grid;
+        grid-template-areas: 'articleText articleImages';
+        grid-template-rows: 1fr;
+        grid-template-columns: 6fr 4fr;
+        grid-gap: 1rem;
+
+        .article__text,
+        .article__image {
+          float: none;
+          width: auto;
+          margin: 0;
+        }
+      }
+
+      .article__text {
+        grid-area: articleText;
+      }
+
+      .article__image {
+        grid-area: articleImages;
+        width: 100%;
+      }
+    }
+  }
+
   @media screen {
-    //—— Read more: initial ————————————————————————————————————————————————————
+    //
+    // Read more: initial state
+    //
     .article__text.article--has-more {
       position: relative;
       max-height: 280px;
@@ -228,7 +234,9 @@
       }
     }
 
-    //—— Read more: Expanded ———————————————————————————————————————————————————
+    //
+    // Read more: Expanded state
+    //
     .article--has-more.is--expanded {
       max-height: 1000px;
 
@@ -240,9 +248,12 @@
         opacity: 0;
       }
     }
-
   } // @media screen
 
+
+  //
+  // Print layout
+  //
   @media print {
     .article__image {
       float: right;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -43,8 +43,7 @@
       box-shadow: none;
       border-radius: 0;
       border-bottom: 1px solid #ddd;
-      padding: 0 1rem;
-      padding-bottom: 2rem;
+      padding: 0 0 1rem 0;
     }
   }
 </style>

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -66,7 +66,8 @@
       page-break-inside: avoid;
     }
     .data {
-      color: inherit;
+      color: #4A8CCA;
+      color: cmyk(68, 34, 0 , 0);
     }
     figcaption {
       color: #67696C;

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -33,8 +33,12 @@
   width: 100%;
   border-radius: 5px;
 }
+.message {
+  font-size: 1.1em;
+  margin-bottom: 1rem;
+}
 
-@media print, screen and (min-width: 800px) {
+@media print and (min-width: 6in), screen and (min-width: 800px) {
   .key-messages__area {
   }
   .message-list {
@@ -42,7 +46,6 @@
     float: left;
   }
   .message {
-    font-size: 1.1em;
     margin-right: 1rem;
   }
   .image {
@@ -60,7 +63,7 @@
       display: grid;
       grid-template-areas: "km-messages km-image";
       grid-template-rows: 1fr;
-      grid-template-columns: 1fr 2fr;
+      grid-template-columns: 1fr 1fr;
       grid-gap: 1rem;
     }
 
@@ -82,9 +85,15 @@
       content: none;
     }
   }
-} /* print, screen and (min-width: 800px) */
+} /* print and (min-width: 6in), screen and (min-width: 800px) */
 
 @media print {
+  .card--keyMessages {
+    padding: 0 0 2rem 0;
+  }
+  .message-list {
+    padding-top: 0;
+  }
   .message {
     font-size: 1em;
   }

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -35,7 +35,7 @@
   const active_content_type = 'sitrep';
 
   export default {
-    // Declare any components we're using here
+    // Declare all child components we're using.
     components: {
       AppBar,
       AppFooter,
@@ -75,7 +75,8 @@
 
 /*—— Report Medium layout ——————————————————————————————————————————————*/
 
-@media screen and (min-width: 760px) {
+@media print and (min-width: 10cm),
+       screen and (min-width: 760px) {
   @supports (display: grid) {
     .section--primary {
       display: grid;
@@ -104,12 +105,11 @@
       grid-area: contacts;
     }
   } /* @supports (display: grid) */
-} /* @media screen and (min-width: 760px) */
+} /* @media print and (min-width: 10cm), screen and (min-width: 760px) */
 
 /*—— Report Large/Print layout —————————————————————————————————————————————————————*/
 
-@media print and (min-width: 15cm),
-       screen and (min-width: 1164px) {
+@media screen and (min-width: 1164px) {
   /**
    * No CSS Grid support
    *
@@ -182,7 +182,7 @@
       margin-bottom: 1rem;
     }
   } /* @supports (display: grid) */
-} /* @media print and (min-width: 15cm), screen and (min-width: 1164px) */
+} /* @media screen and (min-width: 1164px) */
 
 /*—— Print styles ————————————————————————————————————————————————————————————*/
 @media print {
@@ -193,21 +193,30 @@
   .section--primary {
     border-bottom: 1px solid #ddd;
   }
+  .section--everythingElse {
+    page-break-before: always;
+    padding-top: 10mm;
+  }
+  .section--everythingElse .card:last-child {
+    border-bottom: 0;
+  }
 
   .card--keyMessages {
-    border-right: 1px solid #ddd;
-    border-bottom: 0;
-    padding: 0;
     font-size: 1em;
   }
   .card--keyFigures {
-    border-bottom: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    border-bottom: 0;
+    padding-top: 1em;
   }
   .card--keyFinancials {
-    border-bottom: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    border-bottom: 0;
+    padding-top: 1em;
   }
   .card--contacts {
-    border-bottom: 0;
+    border: 0;
+    padding-top: 1em;
   }
 }
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -215,6 +215,9 @@ main code {
 .md * {
   margin-bottom: 1em;
 }
+.md *:last-child {
+  margin-bottom: 0;
+}
 .md p {
   line-height: 1.5;
 }
@@ -227,17 +230,30 @@ main code {
 
 @media print {
   body {
+    /**
+     * Correct the colors on the printouts using Snap Service (Puppeteer).
+     */
+    -webkit-print-color-adjust: exact;
+
     background-color: white;
     font-size: 10pt !important;
+    padding: 10mm;
   }
 
-  main ul {
-    padding: 0 0 0 1em;
+  .container {
+    margin: 0;
   }
 
-  .md a[href]::after {
-    content: " (" attr(href) ") ";
+  main p {
+    orphans: 3;
+    widows: 3;
+  }
+
+  .md a[href] {
     text-decoration: none;
+  }
+  .md a[href]::after {
+    content: " <" attr(href) "> ";
   }
 }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-42

This finally brings us to something I can call an MVP without wincing. Biggest improvement was the color matching, which now should be pretty close to expected output instead of darker, less saturated colors.

Lots of margins/paddings tweaked, I tried to eliminate left/right whitespace and let the 10mm page margin do the work of providing a border.

Some code re-org happened in the process as I found a convention I was happy with in terms of defining print styles. When the layout differs drastically I defined a block with several rules. When it was just one prop being overridden I opted for nested media blocks using the SCSS syntax.

Snap PDF: [DSR-42-print-r2.pdf](https://github.com/UN-OCHA/reports-site/files/2495489/DSR-42-print-r2.pdf)
