### PR TITLE
DSR-42: adjust image captions on PDF printout

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -137,7 +137,7 @@
       border-radius: 5px 0 5px 0;
     }
     @media print {
-      margin: .25cm 1cm;
+      margin: .25cm;
       color: black;
       background: none;
       font-style: italic;


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-42

Further adjustments based on some feedback from 18 Oct demo. Image captions have less horizontal margin and expand to mostly the full-width of the image itself.