### PR TITLE
DSR-5: Social Integration

### DIFF
--- a/_migrations/04-update-keyMessages.js
+++ b/_migrations/04-update-keyMessages.js
@@ -1,6 +1,10 @@
 module.exports = function(migration) {
   const sitrep = migration.editContentType('sitrep')
 
+  // Remove "V1" from the name of the SitRep content type.
+  sitrep
+    .name('Situation Report')
+
   //
   // Move keyMessages field from the old KM section to a direct child of SitRep,
   // retain all previous validations, and change editor UI to be bulk editable.
@@ -30,6 +34,32 @@ module.exports = function(migration) {
       bulkEditing: true
     })
 
+  sitrep
+    .createField('keyMessagesImage')
+    .name('Key Image')
+    .type('Link')
+    .linkType('Asset')
+    .validations([
+      {
+        'assetImageDimensions': {
+          'width': {'min': 400, 'max': 2400},
+          'height': {'min': 400,'max': 1800}
+        },
+        'message': 'Title will be used for accessibility purposes and should explain the image contents. Description will be overlaid on top of the image as supplementary information (e.g. photo credits)'
+      }
+    ])
+    .required(true)
+
+  sitrep
+    .moveField('keyMessagesImage')
+    .afterField('dateUpdated')
+
+  // Delete old Key Message Section reference from SitRep. Content Type will be
+  // deleted later on during this migration.
+  sitrep
+    .deleteField('keyMessageSection')
+
+
   const keyMessage = migration.editContentType('keyMessage')
 
   //
@@ -55,4 +85,11 @@ module.exports = function(migration) {
   keyMessage
     .deleteField('message')
 
+
+  //
+  // Delete old KeyMessageSection content type.
+  //
+  // NOTE: Requires manual deletion of the Entries before migration is run.
+  //
+  const keyMessageSection = migration.deleteContentType('keyMessageSection')
 };

--- a/_migrations/04-update-keyMessages.js
+++ b/_migrations/04-update-keyMessages.js
@@ -1,0 +1,58 @@
+module.exports = function(migration) {
+  const sitrep = migration.editContentType('sitrep')
+
+  //
+  // Move keyMessages field from the old KM section to a direct child of SitRep,
+  // retain all previous validations, and change editor UI to be bulk editable.
+  //
+  sitrep
+    .createField('keyMessages', {
+      items: {
+        type: 'Link',
+        linkType: 'Entry',
+        validations: [
+          { linkContentType: ['keyMessage'] }
+        ]
+      }})
+    .name('Key Messages')
+    .type('Array')
+    .validations([
+      { 'size': {min: 2, max: 5} }
+    ])
+    .required(true)
+
+  sitrep
+    .moveField('keyMessages')
+    .afterField('dateUpdated')
+
+  sitrep
+    .changeEditorInterface('keyMessages', 'entryCardsEditor', {
+      bulkEditing: true
+    })
+
+  const keyMessage = migration.editContentType('keyMessage')
+
+  //
+  // Destroy Long field and replace with Symbol. Retain all previous validations.
+  //
+  keyMessage
+    .createField('keyMessage')
+    .name('Message')
+    .type('Symbol')
+    .validations([
+      {
+        'size': {max: 180},
+        'message': 'Please write a shorter Key Message. Include the most important  details and save longer points for the Analysis section below.'
+      }
+    ])
+    .required(true)
+
+  // Use new field's contents as title
+  keyMessage
+    .displayField('keyMessage')
+
+  // Remove old field
+  keyMessage
+    .deleteField('message')
+
+};

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -7,22 +7,31 @@
 
       <h1 class="title" v-if="title">{{ title }}</h1>
       <h1 class="title" v-else>Situation Reports</h1>
-
       <span class="subtitle" v-if="title">Situation Report</span>
       <span class="subtitle" v-else>United Nations Office for the Coordination of Humanitarian Affairs</span>
-
       <span class="last-updated" v-if="updated"><span class="viz--480">Last </span> updated: <time :datetime="updated">{{ $moment(updated).format('YYYY-MM-DD') }}</time></span>
       <span class="last-updated" v-else aria-hidden="true">&nbsp;</span>
     </div>
     <div class="meta-area">
-      <a class="subscribe" v-if="mailchimp" :href="mailchimp" target="_blank" rel="noopener">Subscribe</a>
+      <a class="share subscribe" v-if="mailchimp" :href="mailchimp" target="_blank" rel="noopener">Subscribe</a>
+      <a class="share twitter" v-if="social && this.socialUrlTwitter" :href="socialUrlTwitter" target="_blank" rel="noopener">Tweet</a>
+      <a class="share facebook" v-if="social && this.socialUrlFacebook" :href="socialUrlFacebook" target="_blank" rel="noopener">Facebook</a>
     </div>
   </header>
 </template>
 
 <script>
   export default {
-    props: ['title', 'updated', 'mailchimp']
+    props: ['title', 'updated', 'mailchimp', 'social'],
+    data() {
+      let socialMessage = 'This is a placeholder message.';
+      let socialBaseUrl = typeof window !== "undefined" ? encodeURIComponent(window.location.href) : `${process.env.baseUrl}${this.$route.path}`;
+
+      return {
+        socialUrlFacebook: `https://www.facebook.com/sharer/sharer.php?u=${socialBaseUrl}`,
+        socialUrlTwitter: `https://twitter.com/intent/tweet?text=${socialMessage}%0A%0A${socialBaseUrl}`,
+      }
+    }
   }
 </script>
 
@@ -134,10 +143,11 @@
     text-transform: capitalize;
   }
 
-  .subscribe {
+  .share {
     display: inline-block;
     border-radius: 1em;
     padding: .25em 1em;
+    margin-bottom: .25em;
     background: #4c8cca;
     color: white;
     text-decoration: none;

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -7,7 +7,7 @@
           {{ message.fields.keyMessage }}
         </li>
       </ul>
-      <!-- <img class="image" :src="keyImage.fields.file.url" :alt="keyImage.fields.description"> -->
+      <img class="image" :src="image.fields.file.url" :alt="image.fields.description">
     </div>
     <CardActions :frag="'#' + this.cssId" />
   </article>
@@ -17,7 +17,7 @@
   import Card from './Card.vue';
   export default {
     extends: Card,
-    props: ['messages', 'keyImage'],
+    props: ['messages', 'image'],
     computed: {
       cssId() {
         return `cf-${this.messages.map((msg) => msg.sys.id).join('_')}`;

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -3,12 +3,11 @@
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">
-        <li :key="message.sys.id" v-for="message in content.fields.keyMessages" class="message">
-          <h4>{{ message.fields.title }}</h4>
-          <div class="md" v-html="$md.render(message.fields.message)"></div>
+        <li :key="message.sys.id" v-for="message in messages" class="message">
+          {{ message.fields.keyMessage }}
         </li>
       </ul>
-      <img class="image" :src="content.fields.keyMessageMainImage.fields.file.url" :alt="content.fields.keyMessageMainImage.fields.description">
+      <!-- <img class="image" :src="keyImage.fields.file.url" :alt="keyImage.fields.description"> -->
     </div>
     <CardActions :frag="'#' + this.cssId" />
   </article>
@@ -18,10 +17,10 @@
   import Card from './Card.vue';
   export default {
     extends: Card,
-    props: ['content'],
+    props: ['messages', 'keyImage'],
     computed: {
-      cssId: function () {
-        return 'cf-' + this.content.sys.id;
+      cssId() {
+        return `cf-${this.messages.map((msg) => msg.sys.id).join('_')}`;
       }
     }
   }
@@ -36,6 +35,7 @@
 .message {
   font-size: 1.1em;
   margin-bottom: 1rem;
+  line-height: 1.5;
 }
 
 @media print and (min-width: 6in), screen and (min-width: 800px) {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,6 +8,7 @@ module.exports = {
     CTF_SPACE_ID: api.CTF_SPACE_ID,
     CTF_ENVIRONMENT: api.CTF_ENVIRONMENT,
     CTF_CDA_ACCESS_TOKEN: api.CTF_CDA_ACCESS_TOKEN,
+    baseUrl: api.BASE_URL || 'https://reports.unocha.org',
   },
   //
   // Global <head> metadata

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,7 +21,7 @@ module.exports = {
       { charset: 'utf-8' },
       { 'http-equiv': 'X-UA-Compatible', content: 'IE=edge' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { name: 'description', content: 'Digital Situation Report' }
+      { hid: 'dsr-desc', name: 'description', content: 'Digital Situation Reports' }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -9,7 +9,7 @@
 
     <main class="container report">
       <section class="section--primary clearfix">
-        <KeyMessages :messages="entry.fields.keyMessages" />
+        <KeyMessages :messages="entry.fields.keyMessages" :image="entry.fields.keyMessagesImage" />
         <KeyFigures :content="entry.fields.keyFigure" />
         <KeyFinancials :content="entry.fields.keyFinancialsManual" :ftsUrl="entry.fields.keyFinancialsUrl" />
         <Contacts :content="entry.fields.contacts" />
@@ -80,7 +80,7 @@
 
         // @see https://nuxtjs.org/api/pages-head/
         meta: [
-          { hid: 'dsr-desc', name: 'description', content: this.entry.fields.keyMessageSection.fields.keyMessages.map(msg => msg.fields.message).join(' — ') },
+          { hid: 'dsr-desc', name: 'description', content: this.entry.fields.keyMessages.map(msg => msg.fields.keyMessage).join(' — ') },
           { hid: 'tw-dnt', name: 'twitter:dnt', content: 'on' },
           { hid: 'tw-card', name: 'twitter:card', content: 'summary_large_image' },
           { hid: 'tw-title', name: 'twitter:title', content: 'Digital Situation Report: ' + this.entry.fields.title },
@@ -89,8 +89,8 @@
           { hid: 'og-type', name: 'og:type', content: 'website' },
           { hid: 'og-url', name: 'og:url', content: `https://reports.unocha.org/country/${this.entry.fields.slug}` },
           { hid: 'og-title', name: 'og:title', content: this.entry.fields.title },
-          { hid: 'og-desc', name: 'og:description', content: this.entry.fields.keyMessageSection.fields.keyMessages.map(msg => msg.fields.message).join(' — ') },
-          { hid: 'og-image', name: 'og:image', content: 'https:' + this.entry.fields.keyMessageSection.fields.keyMessageMainImage.fields.file.url },
+          { hid: 'og-desc', name: 'og:description', content: this.entry.fields.keyMessages.map(msg => msg.fields.keyMessage).join(' — ') },
+          { hid: 'og-image', name: 'og:image', content: 'https:' + this.entry.fields.keyMessagesImage.fields.file.url },
         ],
       };
     },

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -51,13 +51,13 @@
     },
 
     // Validate the country slug using this function.
-    validate ({params}) {
+    validate({params}) {
       return typeof params.slug === 'string';
     },
 
     // In order to render a dynamic page title, we first set up the empty object
     // that will be populated by asyncData.
-    data () {
+    data() {
       return {
         entry: {},
       }
@@ -74,11 +74,26 @@
       return {
         // %s is the default site title. In our case the name of the website.
         titleTemplate: `${pageTitle} | %s`,
+
+        // @see https://nuxtjs.org/api/pages-head/
+        meta: [
+          { hid: 'dsr-desc', name: 'description', content: this.entry.fields.keyMessageSection.fields.keyMessages.map(msg => msg.fields.message).join(' — ') },
+          { hid: 'tw-dnt', name: 'twitter:dnt', content: 'on' },
+          { hid: 'tw-card', name: 'twitter:card', content: 'summary_large_image' },
+          { hid: 'tw-title', name: 'twitter:title', content: 'Digital Situation Report: ' + this.entry.fields.title },
+          { hid: 'tw-site', name: 'twitter:site', content: '@UNOCHA' },
+          { hid: 'tw-creator', name: 'twitter:creator', content: '@UNOCHA' },
+          { hid: 'og-type', name: 'og:type', content: 'website' },
+          { hid: 'og-url', name: 'og:url', content: `https://reports.unocha.org/country/${this.entry.fields.slug}` },
+          { hid: 'og-title', name: 'og:title', content: this.entry.fields.title },
+          { hid: 'og-desc', name: 'og:description', content: this.entry.fields.keyMessageSection.fields.keyMessages.map(msg => msg.fields.message).join(' — ') },
+          { hid: 'og-image', name: 'og:image', content: 'https:' + this.entry.fields.keyMessageSection.fields.keyMessageMainImage.fields.file.url },
+        ],
       };
     },
 
     // Nuxt uses this to make async API calls to Contentful during SSR.
-    asyncData ({env, params}) {
+    asyncData({env, params}) {
       return Promise.all([
         // Fetch single Entry by slug
         client.getEntries({

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="page--sitrep" :id="'cf-' + entry.sys.id">
     <AppBar />
-    <AppHeader :title="entry.fields.title" :updated="entry.fields.dateUpdated" :mailchimp="entry.fields.mailchimpSignup" />
+    <AppHeader
+      :title="entry.fields.title"
+      :updated="entry.fields.dateUpdated"
+      :mailchimp="entry.fields.mailchimpSignup"
+      :social="true" />
 
     <main class="container report">
       <section class="section--primary clearfix">
@@ -55,8 +59,7 @@
       return typeof params.slug === 'string';
     },
 
-    // In order to render a dynamic page title, we first set up the empty object
-    // that will be populated by asyncData.
+    // Set up an empty object that will be populated by asyncData.
     data() {
       return {
         entry: {},

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -9,7 +9,7 @@
 
     <main class="container report">
       <section class="section--primary clearfix">
-        <KeyMessages :content="entry.fields.keyMessageSection" />
+        <KeyMessages :messages="entry.fields.keyMessages" />
         <KeyFigures :content="entry.fields.keyFigure" />
         <KeyFinancials :content="entry.fields.keyFinancialsManual" :ftsUrl="entry.fields.keyFinancialsUrl" />
         <Contacts :content="entry.fields.contacts" />

--- a/static/global.css
+++ b/static/global.css
@@ -1,5 +1,7 @@
 /**
- * Until a better build system is in place, global styles go here
+ * Global, site-wide CSS.
+ *
+ * Styles specific to a components should be included inside each .vue file.
  */
 
 *,


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-5

This PR introduces two aspects to integrate with social media:

- New `<meta>` tags that follow both Twitter and Open Graph (FB) protocol. These tags influence the rich snippets generated by sharing a URL on various platforms. We're using `summary_large_image` on Twitter and FB doesn't offer a similar option.
- Links to the sharing tools on Twitter/FB. We're starting out by using the very lightweight "intents" versions instead of loading tweet/like buttons with badges, which require 3rd-party JS.

<img width="567" alt="dsr-5-social-twitter-preview" src="https://user-images.githubusercontent.com/254753/47993852-ee532780-e0f0-11e8-8357-e83af0186994.png">
