### PR TITLE
DSR-55: Cluster fixes

### DIFF
--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -5,8 +5,10 @@
       <h3 class="cluster__title">{{ content.fields.clusterName }}</h3>
       <div class="figures clearfix" v-if="content.fields.clusterFigures">
         <figure v-for="figure in content.fields.clusterFigures" :key="figure.sys.id">
-          <span class="data">{{ figure.fields.figure }}</span>
-          <figcaption>{{ figure.fields.caption }}</figcaption>
+          <div v-if="typeof figure !== 'undefined' && typeof figure.fields !== 'undefined' && typeof figure.fields.figure !== 'undefined'">
+            <span class="data">{{ figure.fields.figure }}</span>
+            <figcaption>{{ figure.fields.caption }}</figcaption>
+          </div>
         </figure>
       </div>
     </div>

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -79,15 +79,26 @@
     margin-bottom: 1rem;
   }
 
+  //
+  // Float layout for old desktops.
+  //
   @media (min-width: 700px) {
     .cluster__title {
       float: left;
       width: 49%;
     }
+
+    // Cluster Figures flow from the right, not left like KF.
     .figures {
       float: right;
       width: 49%;
       text-align: right;
+      flex-direction: row-reverse;
+
+      * {
+        flex-basis: 50%;
+        padding-left: 1rem;
+      }
     }
   }
 
@@ -116,23 +127,9 @@
 
     @supports (display: grid) {
       .cluster__meta {
-        display: grid;
-        grid-template-columns: 2fr 1fr;
-        grid-gap: 1rem;
         padding-bottom: 0;
         margin-bottom: 1rem;
         page-break-after: always;
-
-        // unset legacy layout
-        * {
-          float: none;
-          width: auto;
-          margin: 0;
-        }
-
-        .figures {
-          grid-gap: 0;
-        }
       }
 
       .cluster__content {

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -27,38 +27,20 @@
 <!-- NOT scoped so we can be inherited by other components which use Figures -->
 <style lang="scss">
   .figures {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
     figure {
-      float: left;
-      width: 49%;
+      flex-basis: 50%;
       margin-bottom: 1rem;
     }
 
-    .none {
-      width: 100%;
-      float: none;
-      margin-bottom: 1rem;
+    .figures-none {
+      flex-basis: 100%;
     }
-  }
 
-  @supports (display: grid) {
-    .figures {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-gap: 1rem;
-
-      figure {
-        float: none;
-        width: auto;
-        margin-bottom: 0;
-      }
-
-      .none {
-        grid-column: 1 / span 2;
-      }
-    }
-  }
-
-  .figures {
     .data {
       font-family: sans-serif;
       font-size: 2em;

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -2,7 +2,7 @@
   <section class="card card--keyFinancials" :id="this.cssId">
     <h2 class="card__title">Key Financials</h2>
     <div class="figures clearfix">
-      <div v-if="!content" class="none">
+      <div v-if="!content" class="figures-none">
         No Financial data to display.
       </div>
       <figure v-else v-for="figure in content" :key="figure.sys.id">


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-55

- Fixed visual issues on desktop Clusters when only one Figure is present. Swapped out CSS Grid for Flexbox, which then means Clusters can flow from the right side in desktop. At the same time fixed IE11 issues.
- Protect against situations where unpublished Figures are included in a published Cluster. grrr.

Did some thorough browser testing because the CSS adjustments were kind of fundamental to the display of Figures in general:

- Win8.1 - IE11
- Win10 - Edge 17
- macOS - FF
- macOS - Chrome
- macOS - Safari (Mojave)
- iPhone 6 - iOS 11 - Safari
- iPhone X - iOS 12 - Safari
- Nexus 5X - Android 7 - FF
