### PR TITLE
DSR-54: Articles with Rich Text

### DIFF
--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -33,7 +33,6 @@
 <script>
   import Card from './Card.vue';
   import KeyFigures from './KeyFigures.vue';
-  // import { BLOCKS.PARAGRAPH } from '@contentful/rich-text-types';
   import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 
   export default {
@@ -44,14 +43,16 @@
         return 'cf-' + this.content.sys.id;
       }
     },
+
     data() {
       return {
         richNeeds: '',
         richResponse: '',
         richGaps: '',
-      }
+      };
     },
-    beforeMount() {
+
+    created() {
       // Any custom render-methods would go here.
       const richOptions = {};
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,13 +37,9 @@ module.exports = {
   // Additional modules for our site
   //
   modules: [
-    '@nuxtjs/markdownit',
     ['@nuxtjs/moment', ['fr']],
     ['@nuxtjs/google-tag-manager', { id: 'GTM-W4PXQBG' }],
   ],
-  markdownit: {
-    injected: true
-  },
   //
   // Build configuration
   //

--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,25 +2017,6 @@
       "resolved": "https://registry.npmjs.org/@nuxtjs/google-tag-manager/-/google-tag-manager-2.1.0.tgz",
       "integrity": "sha512-NmEqiidNC/sPjizURKT8fMIe41Q/R2egIFICeOfNcCqZfxJjHttUjQaYMJ+ef7bn50N724tCain+vQocUZjliw=="
     },
-    "@nuxtjs/markdownit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/markdownit/-/markdownit-1.2.2.tgz",
-      "integrity": "sha512-QdL0+L+NJD0Sr2UeMO+gFY7w4l4h1xYaYUaDx8H3ob/Zha2TapeXaYgD+PGhjUhWfnLFGc5cqcdsNI9+9Tt1oQ==",
-      "requires": {
-        "@nuxtjs/markdownit-loader": "^1.1.1",
-        "raw-loader": "^0.5.1"
-      }
-    },
-    "@nuxtjs/markdownit-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/markdownit-loader/-/markdownit-loader-1.1.1.tgz",
-      "integrity": "sha512-ijbEL5QOTRGuykwpikxaanxv5QntRiGYPtBDFvvdhoVNpsfbvROk1QnxCd2tMaYo6zKtpjFQS1RXcluwn5oTXg==",
-      "requires": {
-        "highlight.js": "^9.12.0",
-        "loader-utils": "^1.1.0",
-        "markdown-it": "^8.3.1"
-      }
-    },
     "@nuxtjs/moment": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/@nuxtjs/moment/-/moment-1.0.0.tgz",
@@ -6024,11 +6005,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
-    "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6851,14 +6827,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "listr": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
@@ -7448,18 +7416,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      }
-    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -7473,11 +7429,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -9736,11 +9687,6 @@
         }
       }
     },
-    "raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
-    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -11412,11 +11358,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@contentful/rich-text-html-renderer": "^9.0.0",
     "@contentful/rich-text-types": "^9.0.0",
     "@nuxtjs/google-tag-manager": "^2.1.0",
-    "@nuxtjs/markdownit": "^1.2.2",
     "@nuxtjs/moment": "^1.0.0",
     "ajv": "^6.5.4",
     "axios": "^0.18.0",

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -16,8 +16,8 @@
       </section>
 
       <section class="section--everythingElse">
-        <Cluster :content="cluster" v-for="cluster in entry.fields.clusters" :key="cluster.sys.id" />
-        <Article :content="article" v-for="article in entry.fields.article" :key="article.sys.id" />
+        <Cluster :content="cluster" v-for="cluster in entry.fields.clusters" :key="cluster.sys.id" v-if="typeof cluster !== 'undefined' && typeof cluster.fields !== 'undefined'" />
+        <Article :content="article" v-for="article in entry.fields.article" :key="article.sys.id" v-if="typeof article !== 'undefined' && typeof article.fields !== 'undefined'" />
       </section>
     </main>
 

--- a/static/global.css
+++ b/static/global.css
@@ -211,28 +211,22 @@ main code {
   border-radius: 3px;
 }
 
-/*—— Markdown ————————————————————————————————————————————————————————————————*/
-
-.md {}
-.md * {
-  margin-bottom: 1em;
-}
-.md *:last-child {
-  margin-bottom: 0;
-}
-.md p {
-  line-height: 1.5;
-}
-.md p img {
-  display: block;
-  margin: 1em 0;
-}
-
 /*—— Rich Text ———————————————————————————————————————————————————————————————*/
 
 .rich-text {}
-.rich-text p {
+.rich-text * {
   margin-bottom: 1em;
+}
+.rich-text *:last-child {
+  margin-bottom: 0;
+}
+.rich-text p {
+  line-height: 1.5;
+  margin-bottom: 1em;
+}
+.rich-text p img {
+  display: block;
+  margin: 1em 0;
 }
 .rich-text ul,
 .rich-text ol {
@@ -269,10 +263,10 @@ main code {
     widows: 3;
   }
 
-  .md a[href] {
+  .rich-text a[href] {
     text-decoration: none;
   }
-  .md a[href]::after {
+  .rich-text a[href]::after {
     content: " <" attr(href) "> ";
   }
 }


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-54

This PR converts Articles to use the Rich Text field type instead of the more-permissive Markdown long-text field. I also enforced validation on heading/title/body to avoid situations where an article was malformed.

- **Major victory:** I removed Markdown from the codebase completely since no other component, reducing the JS payload from 418K to 330K  🎉 
- Defends against unpublished Clusters/Article references breaking page builds.
- Renders all existing Rich Text fields using a more appropriate Vue Component Lifecycle event, meaning the content now appears in SSR instead of needing client-side JS. This was an unfound bug so now it's fixed 👍 

I briefly looked into the migration process but decided to skip it since the amount of text fields affected was four. I manually copied the fields and will prune the old field from the Content Model once this deploys.
