### PR TITLE
DSR-39: PNG downloads

### DIFF
--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="actions" v-show="!snapInProgress">
-    <button class="btn btn--download" @click="requestSnap"><span class="element-invisible">Save as PNG</span></button>
+  <div class="actions">
+    <button class="btn btn--download"
+            :class="{ 'btn--is-active': snapInProgress }"
+            @click="requestSnap"
+            :disabled="snapInProgress">
+      <span class="element-invisible">Save as PNG</span>
+    </button>
   </div>
 </template>
 
@@ -8,12 +13,16 @@
   import axios from 'axios';
 
   export default {
-    props: ['frag'],
+    props: {
+      'frag': String,
+    },
+
     data() {
       return {
         snapInProgress: false,
-      };
+      }
     },
+
     methods: {
       requestSnap: function() {
         const sitRepUrl = window.location.href;
@@ -21,7 +30,6 @@
         const snapRequest = `${snapEndpoint}?url=${encodeURIComponent(sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.frag)}`;
 
         setTimeout(() => {this.snapInProgress = true;}, 166); // 166ms to allow CSS transition to finish
-        // console.log('😃🤳 Snap requested...', snapRequest);
 
         axios({
             url: snapRequest,
@@ -53,7 +61,10 @@
       },
 
       handleSnapFailure(err) {
+        // Reset the UI
         this.snapInProgress = false;
+
+        // For now, we are only logging the error in console. No visual feedback.
         console.error('handleSnapFailure:', err);
       },
     }
@@ -71,24 +82,22 @@
     right: 1rem;
   }
 
-  .actions .btn {
+  .btn {
     width: 1rem;
     height: 1rem;
     border: 0;
     margin: 0;
     margin-left: .5rem;
     opacity: 1;
-    transition: opacity .3333s ease-out;
+    cursor: pointer;
+    transform: scale(1); // baseline for animation
+    transition: .3333s ease-out;
+    transition-property: opacity, transform;
   }
 
-  .actions .btn:hover {
+  .btn:hover {
     opacity: .8;
     transition: opacity .1666s ease-out;
-  }
-
-  .actions .btn:focus {
-    animation: clicked .1666s ease-in;
-    animation-fill-mode: forwards;
   }
 
   .btn--download {
@@ -109,6 +118,17 @@
     to {
       transform: translateZ(300px) scale(5);
       opacity: 0;
+    }
+  }
+
+  .btn--is-active {
+    animation: is-active 1s ease-in-out infinite;
+    cursor: wait;
+  }
+
+  @keyframes is-active {
+    50% {
+      transform: scale(1.3333);
     }
   }
 </style>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-39

- Allows a PNG to download within the visitor's desktop browser. There's no presentation of the graphic within the web browser. It simply downloads and — depending on a person's browser settings — might automatically open in an app (e.g. macOS Preview)
- Provides some minimal UI feedback so the visitor knows something is happening. The button is also disabled, preventing multiple simultaneous requests.

Here's a GIF to demonstrate. The screencapping software mangled the cursor somehow to please refer to this [MDN article about CSS cursors](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) and mouse over the `wait` table row to see what it will look like on your system.

![dsr-39-simple-visual-feedback](https://user-images.githubusercontent.com/254753/48187842-8abd3a00-e33c-11e8-9678-98f47ff83c2e.gif)

