### PR TITLE
DSR-39: add CardHeader/CardFooter for use with Snaps

### DIFF
--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -76,4 +76,11 @@
       display: none;
     }
   }
+
+  //
+  // Snap Service: suppress the bar completely.
+  //
+  .snap--png .app-bar {
+    display: none;
+  }
 </style>

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,5 +1,6 @@
 <template>
   <article class="card card--article article clearfix" :id="this.cssId">
+    <CardHeader />
     <span class="card__title">{{ content.fields.sectionHeading }}</span>
     <div class="article__content" v-bind:class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__image" v-if="content.fields.image">
@@ -14,6 +15,7 @@
       </div>
     </div>
     <CardActions :frag="'#' + this.cssId" />
+    <CardFooter />
   </article>
 </template>
 
@@ -226,6 +228,9 @@
     //
     // Read more: Expanded state
     //
+    // Also used by Snap Service.
+    //
+    .snap--png .article__text.article--has-more,
     .article--has-more.is--expanded {
       max-height: 1000px;
 

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -6,14 +6,27 @@
 
 <script>
   import CardActions from './CardActions.vue';
+  import CardHeader from './CardHeader.vue';
+  import CardFooter from './CardFooter.vue';
+
   export default {
     components: {
       CardActions,
+      CardHeader,
+      CardFooter,
     },
-    props: ['content'],
   }
 </script>
 
 <style lang="scss">
+  //
   // Generic Card styles are in app.html — inlined as critical CSS.
+  //
+
+  //
+  // Snap Service: cancel border-radius so we get a perfect rectangle graphic.
+  //
+  .snap--png .card {
+    border-radius: 0;
+  }
 </style>

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -2,8 +2,8 @@
   <div class="actions">
     <button class="btn btn--download"
             :class="{ 'btn--is-active': snapInProgress }"
-            @click="requestSnap"
-            :disabled="snapInProgress">
+            :disabled="snapInProgress"
+            @click="requestSnap">
       <span class="element-invisible">Save as PNG</span>
     </button>
   </div>
@@ -72,7 +72,11 @@
 </script>
 
 <style lang="scss" scoped>
-  .snap--png .actions {
+  // Snap Service applies these classes to <html> while generating a screenshot.
+  // It is not toggled or otherwise invoked by Vue itself. This class is only
+  // used inside Snap Service's Puppeteer process.
+  .snap--png .actions,
+  .snap--pdf .actions {
     display: none;
   }
 

--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -66,6 +66,8 @@
 
         // For now, we are only logging the error in console. No visual feedback.
         console.error('handleSnapFailure:', err);
+
+        alert("PNG Downloads are not fully functional yet.\n\n Thanks for your patience!");
       },
     }
   }

--- a/components/CardFooter.vue
+++ b/components/CardFooter.vue
@@ -1,0 +1,66 @@
+<template>
+  <footer class="card__snap-footer">
+    <p class="url"><span class="label">URL:</span> {{ thisUrl }}</p>
+    <p class="date"><span class="label">Date:</span> <time :datetime="this.today">{{ this.today }}</time></p>
+  </footer>
+</template>
+
+<script>
+  export default {
+    props: {
+      'frag': String,
+    },
+
+    data() {
+      return {}
+    },
+
+    computed: {
+      // Simple date format. Avoiding use of moment.js because it will be
+      // removed in the future.
+      //
+      // Note: this value only displays inside Puppeteer, so it does not need to
+      // be cross-browser.
+      today() {
+        let now = new Date();
+        return now.getFullYear() + '-' + ("00" + (now.getMonth() + 1)).slice(-2) + '-' + ("00" + now.getDate()).slice(-2);
+      },
+
+      // This never needs to run on the server, so just print empty when no window.
+      thisUrl() {
+        return (typeof window !== 'undefined') ? window.location.href : '';
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .card__snap-footer {
+    // DEFAULT: invisible and ignored by screen-readers
+    display: none;
+  }
+
+  // Snap Service applies these classes to <html> while generating a screenshot.
+  // It is not toggled or otherwise invoked by Vue itself. This class is only
+  // used inside Snap Service's Puppeteer process.
+  .snap--png .card__snap-footer,
+  .snap--pdf .card__snap-footer {
+    display: block;
+  }
+
+  .card__snap-footer {
+    color: #4c8cca;
+    border-top: 2px solid currentColor;
+    padding-top: .5rem;
+    margin-top: 1rem;
+    font-size: .8em;
+  }
+
+  .label {
+    color: #222;
+  }
+
+  .url {
+    word-break: break-all;
+  }
+</style>

--- a/components/CardHeader.vue
+++ b/components/CardHeader.vue
@@ -1,0 +1,76 @@
+<template>
+  <header class="card__snap-header">
+    <img class="logo" src="/logo--unocha.svg" alt="Office for the Coordination of Humanitarian Affairs">
+    <div class="meta">
+      <h1 class="title">Burundi</h1>
+      <span class="subtitle">Situation Report</span>
+    </div>
+  </header>
+</template>
+
+<script>
+
+  export default {
+    props: {
+      'frag': String,
+    },
+
+    data() {
+      return {}
+    },
+  }
+</script>
+
+<style lang="scss" scoped>
+  .card__snap-header {
+    // DEFAULT: invisible and ignored by screen-readers
+    display: none;
+  }
+
+  // Snap Service applies these classes to <html> while generating a screenshot.
+  // It is not toggled or otherwise invoked by Vue itself. This class is only
+  // used inside Snap Service's Puppeteer process.
+  .snap--png .card__snap-header,
+  .snap--pdf .card__snap-header {
+    display: grid;
+  }
+
+  .card__snap-header {
+    color: #4c8cca;
+    border-bottom: 2px solid currentColor;
+    padding-bottom: .5rem;
+    margin-bottom: 1rem;
+
+    // display: grid;
+    grid-template-areas: "logo meta";
+    grid-template-columns: 48px 1fr;
+    grid-gap: 0;
+
+    .wf-loaded & {
+      font-family: "Roboto Condensed", serif;
+    }
+  }
+
+  .logo {
+    grid-area: logo;
+    width: 48px;
+    height: 42px;
+    position: relative;
+    top: 3px;
+  }
+
+  .meta {
+    grid-area: meta;
+    padding-left: .5rem;
+    margin-left: 4px;
+    border-left: 1px solid currentColor;
+  }
+
+  .title {
+    text-transform: uppercase;
+    font-size: 24px;
+  }
+  .subtitle {
+    font-size: 18px;
+  }
+</style>

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -1,5 +1,6 @@
 <template>
   <section class="card card--cluster cluster" :id="this.cssId">
+    <CardHeader />
     <h2 class="card__title">Cluster Status</h2>
     <div class="cluster__meta clearfix">
       <h3 class="cluster__title">{{ content.fields.clusterName }}</h3>
@@ -27,6 +28,7 @@
       </div>
     </div>
     <CardActions :frag="'#' + this.cssId" />
+    <CardFooter />
   </section>
 </template>
 
@@ -37,7 +39,11 @@
 
   export default {
     extends: Card,
-    props: ['content'],
+
+    props: {
+      'content': Object,
+    },
+
     computed: {
       cssId() {
         return 'cf-' + this.content.sys.id;

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -12,9 +12,13 @@
 
 <script>
   import Card from './Card.vue';
+
   export default {
     extends: Card,
-    props: ['content'],
+
+    props: {
+      'content': Array,
+    },
   }
 </script>
 

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -1,5 +1,6 @@
 <template>
   <section class="card card--keyFigures" :id="this.cssId">
+    <CardHeader />
     <h2 class="card__title">Key Figures</h2>
     <div class="figures clearfix">
       <figure v-for="figure in content" :key="figure.sys.id">
@@ -8,14 +9,20 @@
       </figure>
     </div>
     <CardActions :frag="'#' + this.cssId" />
+    <CardFooter />
   </section>
 </template>
 
 <script>
   import Card from './Card.vue';
+
   export default {
     extends: Card,
-    props: ['content'],
+
+    props: {
+      'content': Array,
+    },
+
     computed: {
       cssId: function () {
         return 'cf-' + this.content.map((item) => item.sys.id).join('_');

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -1,5 +1,6 @@
 <template>
   <section class="card card--keyFinancials" :id="this.cssId">
+    <CardHeader />
     <h2 class="card__title">Key Financials</h2>
     <div class="figures clearfix">
       <div v-if="!content" class="figures-none">
@@ -12,15 +13,22 @@
     </div>
     <a v-if="!!ftsUrl" :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
     <CardActions :frag="'#' + this.cssId" />
+    <CardFooter />
   </section>
 </template>
 
 <script>
   import Card from './Card.vue';
   import KeyFigures from './KeyFigures.vue';
+
   export default {
     extends: Card,
-    props: ['content', 'ftsUrl'],
+
+    props: {
+      'content': Array,
+      'ftsUrl': String,
+    },
+
     computed: {
       cssId() {
         if (this.content) {

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,5 +1,6 @@
 <template>
   <article class="card card--keyMessages key-messages" :id="this.cssId">
+    <CardHeader />
     <h2 class="card__title">Key Messages</h2>
     <div class="key-messages__area">
       <ul class="message-list">
@@ -10,14 +11,21 @@
       <img class="image" :src="image.fields.file.url" :alt="image.fields.description">
     </div>
     <CardActions :frag="'#' + this.cssId" />
+    <CardFooter />
   </article>
 </template>
 
 <script>
   import Card from './Card.vue';
+
   export default {
     extends: Card,
-    props: ['messages', 'image'],
+
+    props: {
+      'messages': Array,
+      'image': Object,
+    },
+
     computed: {
       cssId() {
         return `cf-${this.messages.map((msg) => msg.sys.id).join('_')}`;

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -51,7 +51,7 @@
       Contacts,
       KeyFigures,
       KeyFinancials,
-      KeyMessages
+      KeyMessages,
     },
 
     // Validate the country slug using this function.


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-39

Display Header/Footer on generated PNGs. The components are generated by the website itself which is why my turnaround on this one was a week faster than PDFs ;)

Any component which extends Card now has the optional ability to include the two new components: `<CardHeader>` and `<CardFooter>`. They are hidden by default but spring to life when the class `snap--png` is applied to the document.

Also included was some cleanup to explicitly define proptypes.
