### PR TITLE
DSR-58: use larger max-height on expanded articles

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -192,7 +192,7 @@
       max-height: 280px;
       overflow: hidden;
       margin-bottom: 1em;
-      transition: max-height .3333s ease-in-out;
+      transition: max-height 1s ease-in-out;
 
       &::before {
         content: '';
@@ -232,7 +232,7 @@
     //
     .snap--png .article__text.article--has-more,
     .article--has-more.is--expanded {
-      max-height: 1000px;
+      max-height: 4000px;
 
       &::before {
         content: none;


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-58

- `max-height` increased to 4000px
- transition time increased to accommodate new `max-height`