### PR TITLE
DSR-61: Key Message alt + caption

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -100,41 +100,6 @@
     margin-bottom: 1rem;
   }
 
-  figure {
-    position: relative;
-
-    @media print {
-      page-break-inside: avoid;
-    }
-  }
-
-  figure img {
-    width: 100%;
-    height: auto;
-    margin: 0;
-    padding: 0;
-    border-radius: 5px;
-  }
-
-  figure img ~ figcaption {
-    @media screen {
-      position: absolute;
-      right: 0;
-      bottom: 4px;
-      max-width: 80%;
-      padding: .666em 1.333em;
-      background: rgba(0,0,0,0.666);
-      color: white;
-      border-radius: 5px 0 5px 0;
-    }
-    @media print {
-      margin: .25cm;
-      color: black;
-      background: none;
-      font-style: italic;
-    }
-  }
-
   @media screen and (min-width: 900px) {
     //
     // Float-based layout

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -8,7 +8,10 @@
           {{ message.fields.keyMessage }}
         </li>
       </ul>
-      <img class="image" :src="image.fields.file.url" :alt="image.fields.description">
+      <figure v-if="image && typeof image.fields !== 'undefined'">
+        <img class="image" :src="'https:' + image.fields.file.url" :alt="image.fields.title">
+        <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
+      </figure>
     </div>
     <CardActions :frag="'#' + this.cssId" />
     <CardFooter />

--- a/static/global.css
+++ b/static/global.css
@@ -240,6 +240,45 @@ main code {
   margin-bottom: 0;
 }
 
+/*—— Captioned Images ————————————————————————————————————————————————————————*/
+
+figure {
+  position: relative;
+}
+
+figure img {
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  border-radius: 5px;
+}
+
+@media screen {
+  figure img ~ figcaption {
+    position: absolute;
+    right: 0;
+    bottom: 4px;
+    max-width: 80%;
+    padding: .666em 1.333em;
+    background: rgba(0,0,0,0.666);
+    color: white;
+    border-radius: 5px 0 5px 0;
+  }
+}
+@media print {
+  figure {
+    page-break-inside: avoid;
+  }
+  figure img ~ figcaption {
+    margin: .25cm;
+    color: black;
+    background: none;
+    font-style: italic;
+  }
+}
+
+
 /*—— Print ———————————————————————————————————————————————————————————————————*/
 
 @media print {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-61

I'd previously been outputting description as the alt text for Key Message image but now it uses Contentful's image-title field. We have no control over fields associated with images but at least we're treating them all the same now. 

I took the liberty of adding the ability to caption the image just like Articles

<img width="1584" alt="dsr-61-km-alt-caption" src="https://user-images.githubusercontent.com/254753/48254769-33d26600-e40b-11e8-8903-873e8680fbe6.png">
