### PR TITLE
make sure nuxt runs generate

### DIFF
--- a/run_node
+++ b/run_node
@@ -6,7 +6,8 @@ cd $NODE_APP_DIR
 CONFIG_FILE=.contentful.json
 if [ ! -f ${CONFIG_FILE} ]; then
     envsubst < ${CONFIG_FILE}.tmpl > ${CONFIG_FILE}
-    node_modules/nuxt/bin/nuxt-generate
+    # node_modules/nuxt/bin/nuxt-generate
+    yarn run generate
 fi
 
 # the deps install and the build occured in the Dockerfile


### PR DESCRIPTION
This is changed because of the latest yarn / npm Nth switchover.
We do want to make sure the first run of a container do generate the static files using the injected env vars, not the fake default ones.