### PR TITLE
DSR-65: use FTS Plan ID from Contentful data

### DIFF
--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -11,7 +11,7 @@
         Financial data could not be found.
       </div>
     </div>
-    <a v-if="!!ftsUrl" :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
+    <a :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
     <CardActions :frag="'#' + this.cssId" />
     <CardFooter />
   </section>
@@ -29,12 +29,6 @@
       'ftsUrl': String,
     },
 
-    data() {
-      return {
-        ftsPlanId: 639,
-      }
-    },
-
     computed: {
       cssId() {
         if (typeof this.content === 'Array' && this.content.length > 0) {
@@ -43,6 +37,10 @@
         else {
           return 'cf-keyFinancials-notAvailable';
         }
+      },
+
+      ftsPlanId() {
+        return Number(this.ftsUrl.match(/\d+/)[0]);
       },
 
       ftsData() {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-65

The last thing! :tada:

PR uses the now-required and strictly-validated FTS URL format in Contentful to extract our Plan ID and dynamically select which FTS dataset we're using.