### PR TITLE
DSR-71: specify image dimensions to aid article height calculations

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -5,7 +5,11 @@
     <div class="article__content" ref="article" :class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__image" v-if="content.fields.image">
         <figure ref="articleImg">
-          <img :src="content.fields.image.fields.file.url" :alt="content.fields.image.fields.title">
+          <img
+            :src="content.fields.image.fields.file.url"
+            :alt="content.fields.image.fields.title"
+            :width="content.fields.image.fields.file.details.image.width"
+            :height="content.fields.image.fields.file.details.image.height">
           <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
         </figure>
       </div>
@@ -87,7 +91,7 @@
       let articleImg = this.$refs['articleImg'];
 
       // Set the article's min-height to the height of the image
-      this.articleMinHeight = (!!articleImg) ? articleImg.clientHeight : this.articleMinHeight;
+      this.articleMinHeight = (!!articleImg) ? Math.max(articleImg.clientHeight, this.articleMinHeight) : this.articleMinHeight;
 
       // If the truncated article text will be sufficiently longer than the
       // accompanying image or the minimum defined in data(), then we apply


### PR DESCRIPTION
Follow-up to #67 — seemed to fix the issue with articles being truncated to near-zero height. I also added a dash of logic to protect against very short images being uploaded. Our current validations don't allow this to occur but it was trivial to add and will come in handy if smaller image dimensions were ever allowed.