### PR TITLE
DSR-75: Share dialog should close when clicks fall outside component

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -25,7 +25,7 @@
         </select>
       </div>
       <div v-if="share" class="share" :class="{ 'share--is-open': this.shareIsOpen }">
-        <button class="share__toggle" @click="toggleShare" @blur="shareIsOpen = false">
+        <button class="share__toggle" @click="toggleShare" @touchend="click" v-on-clickaway="closeShare">
           <span class="element-invisible">{{ $t('Share this page') }}</span>
         </button>
         <div class="share__options card">
@@ -40,9 +40,10 @@
 
 <script>
   import Global from '~/components/_Global';
+  import { mixin as clickaway } from 'vue-clickaway';
 
   export default {
-    mixins: [Global],
+    mixins: [Global, clickaway],
 
     props: {
       'title': String,
@@ -65,8 +66,24 @@
     },
 
     methods: {
+      click(ev) {
+        // In order to normalize touch events, we trigger the click handler
+        // immediately and stop event propagation.
+        this.toggleShare();
+        ev.stopPropagation();
+        ev.preventDefault();
+      },
+
       toggleShare() {
         this.shareIsOpen = !this.shareIsOpen;
+      },
+
+      openShare() {
+        this.shareIsOpen = true;
+      },
+
+      closeShare() {
+        this.shareIsOpen = false;
       },
 
       switchLanguage (localeCode) {
@@ -75,7 +92,7 @@
 
         // Set a cookie for any full refresh that might occur.
         document.cookie = `locale=${localeCode}`;
-      }
+      },
     },
 
     computed: {

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -10,6 +10,16 @@
       locale() {
         return this.$store.state.locale;
       },
+    },
+
+    methods: {
+      // This handler intentionally left blank in order to facilitate click
+      // handling outside the AppHeader > Share component. It uses vue-clickaway
+      // but iPhone does not delegate clicks so we set up a blank handler on
+      // the whole page. It's stupid.
+      //
+      // @see https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+      noop() {}
     }
   }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12291,6 +12291,14 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
       "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
     },
+    "vue-clickaway": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vue-clickaway/-/vue-clickaway-2.2.2.tgz",
+      "integrity": "sha512-25SpjXKetL06GLYoLoC8pqAV6Cur9cQ//2g35GRFBV4FgoljbZZjTINR8g2NuVXXDMLSUXaKx5dutgO4PaDE7A==",
+      "requires": {
+        "loose-envify": "^1.2.0"
+      }
+    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fontfaceobserver": "^2.0.13",
     "moment": "^2.22.2",
     "nuxt": "^2.3.1",
+    "vue-clickaway": "^2.2.2",
     "vue-i18n": "^8.3.2",
     "webpack": "^4.20.2"
   },

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -70,13 +70,6 @@
       }
     },
 
-    methods: {
-      switchLanguage (localeCode) {
-        document.cookie = `locale=${localeCode}`;
-        location.reload();
-      }
-    },
-
     // We use the object populated by asyncData here. It might be empty at first
     // but we can guard against that with a conditional.
     head() {

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page--sitrep" :id="'cf-' + entry.sys.id">
+  <div class="page--sitrep" :id="'cf-' + entry.sys.id" @click="noop">
     <AppBar />
     <AppHeader
       :title="entry.fields.title"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page--front">
+  <div class="page--front" @click="noop">
     <AppBar />
     <AppHeader />
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-75

Mainly an iOS bug as I'd been using `@blur` to accomplish this on desktop. As a bonus I threw in `touchend` support so at least opening the dialog is fast. Unfortunately my quick poking around could not produce the same effect for the clickaway. [Due to reasons](https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html).