### PR TITLE
DSR-78: mobile header

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -5,12 +5,13 @@
         <img class="logo" src="/logo--unocha.svg" :alt="$t('United Nations Office for the Coordination of Humanitarian Affairs', locale)">
       </nuxt-link>
 
-      <h1 class="title" v-if="title">{{ title }}</h1>
-      <h1 class="title" v-else>{{ $t('Situation Reports', locale) }}</h1>
-      <span class="subtitle" v-if="title">{{ $t('Situation Report', locale) }}</span>
-      <span class="subtitle" v-else>{{ $t('United Nations Office for the Coordination of Humanitarian Affairs', locale) }}</span>
-      <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(locale).format('DD MMM YYYY') }}</time></span>
-      <span class="last-updated" v-else aria-hidden="true">&nbsp;</span>
+      <div class="title-area__headings">
+        <h1 class="title" v-if="title">{{ title }}</h1>
+        <h1 class="title" v-else>{{ $t('Situation Reports', locale) }}</h1>
+        <span class="subtitle" v-if="title">{{ $t('Situation Report', locale) }}</span>
+        <span class="subtitle" v-else>{{ $t('United Nations Office for the Coordination of Humanitarian Affairs', locale) }}</span>
+        <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(locale).format('DD MMM YYYY') }}</time></span>
+      </div>
     </div>
     <div class="meta-area">
       <div>
@@ -162,8 +163,13 @@
     }
   }
 
+  .title-area {
+    display: flex;
+    flex-flow: row nowrap;
+  }
+
   .logo-link {
-    float: left;
+    flex: 0 0 53px;
     padding-right: 10px;
     margin-top: 7px;
     margin-right: 10px;
@@ -177,6 +183,10 @@
   .logo {
     width: 53px;
     height: 61px;
+  }
+
+  .title-area__headings {
+    flex: 1 0 90%;
   }
 
   .title {

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -26,12 +26,12 @@
       </div>
       <div v-if="share" class="share" :class="{ 'share--is-open': this.shareIsOpen }">
         <button class="share__toggle" @click="toggleShare" @touchend="click" v-on-clickaway="closeShare">
-          <span class="element-invisible">{{ $t('Share this page') }}</span>
+          <span class="element-invisible">{{ $t('Share this page', locale) }}</span>
         </button>
         <div class="share__options card">
           <a class="share__option share--twitter" v-if="share && this.shareUrlTwitter" :href="shareUrlTwitter" target="_blank" rel="noopener">Twitter</a>
           <a class="share__option share--facebook" v-if="share && this.shareUrlFacebook" :href="shareUrlFacebook" target="_blank" rel="noopener">Facebook</a>
-          <a class="share__option share--email" v-if="share && this.shareUrlEmail" :href="shareUrlEmail" target="_blank" rel="noopener">{{ $t('Email') }}</a>
+          <a class="share__option share--email" v-if="share && this.shareUrlEmail" :href="shareUrlEmail" target="_blank" rel="noopener">{{ $t('Email', locale) }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-78

CSS fixes for mobile header. Tested in IE11 plus some desktops, iPhone 6 Safari (iOS 12) just barely squeezes in the full title on homepage, Android 8 Chrome has some breathing room. SitRep pages have more space until someone puts a gigantor title in there.