### PR TITLE
OPS-4931: create SitRep-specific routes during static site generation

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,13 @@
+// Contentful + Environment variables
 const api = require('./.contentful.json');
+
+// These allow us to query Contentful and get all of our valid URLs.
+const contentful = require('contentful');
+const client = contentful.createClient({
+  space: api.CTF_SPACE_ID,
+  environment: api.CTF_ENVIRONMENT,
+  accessToken: api.CTF_CDA_ACCESS_TOKEN,
+});
 
 module.exports = {
   //
@@ -68,6 +77,25 @@ module.exports = {
           exclude: /(node_modules)/
         })
       }
+    }
+  },
+  //
+  // Static Generation config
+  //
+  generate: {
+    routes: function () {
+      const active_content_type = 'sitrep';
+
+      return client.getEntries({
+          'include': 2,
+          'content_type': active_content_type,
+        })
+        .then((res) => {
+          return res.items.map((page) => {
+            // console.log(page.fields);
+            return route = '/country/' + page.fields.slug;
+          });
+        });
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -92,7 +92,6 @@ module.exports = {
         })
         .then((res) => {
           return res.items.map((page) => {
-            // console.log(page.fields);
             return route = '/country/' + page.fields.slug;
           });
         });

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -64,10 +64,7 @@
 
     // Set up empty objects that will be populated by asyncData.
     data() {
-      return {
-        entry: {},
-        ftsData: {}
-      }
+      return {}
     },
 
     // We use the object populated by asyncData here. It might be empty at first


### PR DESCRIPTION
PR allows `nuxt generate` to create a static HTML for each sitrep