### PR TITLE
DSR-79: Key Message Snap PNG renders at proper height

### DIFF
--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -22,7 +22,13 @@
 
     computed: {
       snapRequest() {
-        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=png&width=${window.innerWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.selector)}&user=ocha&pass=dev`;
+        // To deal with some layout issues on some cards, particularly Key Messages
+        // we want to render the website at a large size, but not trigger the
+        // biggest layout caused by 1164px-wide window. So use 1163 as a minimum
+        // and when the actual width is smaller, we'll use current window.
+        const windowWidth = Math.min(1163, window.innerWidth);
+
+        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=png&width=${windowWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.selector)}&user=ocha&pass=dev`;
       },
     },
   }


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-79

Putting a `Math.min()` on window width with a control value that forces the "medium" grid prevents Key Messages from appearing too tall in the final PNG.