### PR TITLE
DSR-83: Key Figures should. not. have. a. border.

### DIFF
--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -266,7 +266,7 @@
   }
   .card--keyFigures {
     border-right: 1px solid #ddd;
-    border-bottom: 0;
+    border-bottom: 0 !important; /* override shared print/screen Grid styles */
     margin-bottom: 0;
   }
   .card--keyFinancials {


### PR DESCRIPTION
I know I'm missing something here but this only happens on stage. I never see this on my local and fiddling with devtools to manually simulate a PDF Snap led me to this solution.

Trying `!important` as it's within a `@media print` block, and I find it easier to understand than unsetting/resetting the styles in two or three places.