### PR TITLE
DSR-81: try a library instead of bespoke download code

### DIFF
--- a/components/Snap.vue
+++ b/components/Snap.vue
@@ -6,6 +6,7 @@
 
 <script>
   import axios from 'axios';
+  import file from 'file-saver';
   import Global from '~/components/_Global';
 
   export default {
@@ -64,16 +65,8 @@
         // Reset the UI
         this.snapInProgress = false;
 
-        // Force downloading of the PNG
-        // @see https://gist.github.com/Tomassito/a5b4d29f459b9383dc3daa313ae5f73b
-        const url = window.URL.createObjectURL(new Blob([response.data]));
-        const link = document.createElement('a');
-        link.href = url;
-        link.setAttribute('download', this.filename);
-        link.click();
-
-        // Clean up memory
-        window.URL.revokeObjectURL(url);
+        // Download response as file
+        file.saveAs(new Blob([response.data]), this.filename);
       },
 
       handleSnapFailure(err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5752,6 +5752,11 @@
         }
       }
     },
+    "file-saver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.0.tgz",
+      "integrity": "sha512-cYM1ic5DAkg25pHKgi5f10ziAM7RJU37gaH1XQlyNDrtUnzhC/dfoV9zf2OmF0RMKi42jG5B0JWBnPQqyj/G6g=="
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ajv": "^6.5.4",
     "axios": "^0.18.0",
     "contentful": "^7.0.4",
+    "file-saver": "^2.0.0",
     "fontfaceobserver": "^2.0.13",
     "moment": "^2.22.2",
     "nuxt": "^2.3.1",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-81

Trying this to start out with. There are unfortunately many network sads that require a bit of cheating on local development via `Access-Control` headers, proxies, and the like. But with them in place I got Chrome and Safari working. macOS FF still saw through my tricks so deploying this on stage and seeing what happens.

I'll test stage with the full array of browsers to at least document what works and what doesn't. With that table we can decide how much effort to invest.