### PR TITLE
DSR-81: set MIME type on client-side blob to help iOS

### DIFF
--- a/components/Snap.vue
+++ b/components/Snap.vue
@@ -21,6 +21,7 @@
     data() {
       return {
         snapInProgress: false,
+        mimetype: '',
       }
     },
 
@@ -65,8 +66,12 @@
         // Reset the UI
         this.snapInProgress = false;
 
+        if (!this.mimetype) {
+          console.warn('No `mimetype` property was set on the Snap child component.');
+        }
+
         // Download response as file
-        file.saveAs(new Blob([response.data]), this.filename);
+        file.saveAs(new Blob([response.data], {type: this.mimetype}), this.filename);
       },
 
       handleSnapFailure(err) {

--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -20,6 +20,12 @@
       'selector': String,
     },
 
+    data() {
+      return {
+        mimetype: 'image/png',
+      }
+    },
+
     computed: {
       snapRequest() {
         // To deal with some layout issues on some cards, particularly Key Messages

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -22,6 +22,12 @@
       'description': String,
     },
 
+    data() {
+      return {
+        mimetype: 'application/pdf',
+      }
+    },
+
     computed: {
       snapRequest() {
         return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=pdf&media=print&logo=ocha&headerTitle=${encodeURIComponent(this.title.toUpperCase())}&headerSubtitle=${encodeURIComponent(this.subtitle)}&headerDescription=${encodeURIComponent(this.description)}&user=ocha&pass=dev`;


### PR DESCRIPTION
Follow-up to #86 

Setting MIME type on the client-side to help iOS through its struggle.