### PR TITLE
DSR-92: mobile buttons overlap title

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -165,9 +165,7 @@
     margin-top: 1rem;
 
     // for .meta-area__actions
-    @media (min-width: 700px) {
-      position: relative;
-    }
+    position: relative;
   }
 
 
@@ -297,14 +295,8 @@
 
   .meta-area__actions {
     position: absolute;
-    top: 4rem;
-    right: 1rem;
-
-    @media (min-width: 700px) {
-      position: relative;
-      top: auto;
-      right: auto;
-    }
+    bottom: 0;
+    right: 0;
   }
 
   .share {

--- a/static/global.css
+++ b/static/global.css
@@ -98,7 +98,7 @@ html.wf-loaded {
 /* DOWNLOAD URL: https://google-webfonts-helper.herokuapp.com/fonts/roboto?subsets=latin */
 /* roboto-regular - latin */
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
@@ -108,7 +108,7 @@ html.wf-loaded {
 }
 /* roboto-italic - latin */
 /*@font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 400;
@@ -118,7 +118,7 @@ html.wf-loaded {
 }*/
 /* roboto-700 - latin */
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 700;
@@ -130,7 +130,7 @@ html.wf-loaded {
 /* DOWNLOAD URL: https://google-webfonts-helper.herokuapp.com/fonts/roboto-condensed?subsets=latin */
 /* roboto-condensed-regular - latin */
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto Condensed';
   font-style: normal;
   font-weight: 400;
@@ -140,7 +140,7 @@ html.wf-loaded {
 }
 /* roboto-condensed-italic - latin */
 /*@font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto Condensed';
   font-style: italic;
   font-weight: 400;
@@ -150,7 +150,7 @@ html.wf-loaded {
 }*/
 /* roboto-condensed-700 - latin */
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: 'Roboto Condensed';
   font-style: normal;
   font-weight: 700;


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-92

Ugly bug, little fix.

I made two changes. First, I set `font-display: swap` instead of the very-aggressive `optional` — in reality I think we are seeing way too many page loads without webfonts (especially since they are loaded non-blocking) and that directly affects the screen real estate available for the title. The condensed font allows several extra characters to appear before wrapping kicks in.

Secondly, I moved the buttons to always be out of the way. On mobile they sit next to the Subscribe/Language and on desktop their position is unchanged from before.