### PR TITLE
DSR-94: properly handle when no Key Figures are present

### DIFF
--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -8,6 +8,7 @@
         <span v-else class="data">{{ figure.fields.figure }}</span>
         <figcaption>{{ figure.fields.caption }}</figcaption>
       </figure>
+      <p v-if="!content">{{ $t('No data available.', locale) }}</p>
     </div>
     <CardActions :frag="'#' + this.cssId" />
     <CardFooter />

--- a/components/KeyFigures.vue
+++ b/components/KeyFigures.vue
@@ -28,7 +28,12 @@
 
     computed: {
       cssId: function () {
-        return 'cf-' + this.content.map((item) => item.sys.id).join('_');
+        if (typeof this.content === 'Array' && this.content.length > 0) {
+          return 'cf-' + this.content.map((item) => item.sys.id).join('_');
+        }
+        else {
+          return 'cf-keyFigures-notAvailable';
+        }
       }
     }
   }

--- a/locales/en.js
+++ b/locales/en.js
@@ -8,6 +8,7 @@ export default {
   'United Nations Office for the Coordination of Humanitarian Affairs': 'United Nations Office for the Coordination of Humanitarian Affairs',
   'Situation Report': 'Situation Report',
   'Situation Reports': 'Situation Reports',
+  'No data available.': 'No data available.',
 
   // Homepage
   'About this site': 'About this site',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -8,6 +8,7 @@ export default {
   'United Nations Office for the Coordination of Humanitarian Affairs': 'United Nations Office for the Coordination of Humanitarian Affairs',
   'Situation Report': 'Rapport de situation',
   'Situation Reports': 'Rapports de situation',
+  'No data available.': 'No data available.',
 
   // Homepage
   'About this site': 'A propos de ce site',


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-94

App was crashing when Key Figures were not present. I copied over the function from Funding so it outputs a generic ID when there's no data from Contentful.