### PR TITLE
DSR-53: cosmetic fixes to homepage

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,12 +4,13 @@
     <AppHeader />
 
     <main class="container">
-      <section class="card card--intro md">
+      <section class="card card--intro rich-text">
         <h2 class="card__title">{{ $t('About this site', locale) }}</h2>
-        <p>The Digital Situation Report aims to simplify OCHA's current portfolio of field reporting products (Flash Update, Situation Report and Humanitarian Bulletin) by moving out of static PDFs and consolidating into a single online format. It will be more dynamic, visual, and analytical. The platform will save users' time by automating distribution and design. As the system develops further, it will be adapted to pull data and information automatically from other platforms, which will promote consistency across products and facilitate access to wider analysis. By moving to modular, online content, OCHA will advance significantly in its humanitarian reporting.</p>
+        <p>The Digital Situation Report aims to simplify OCHA's current portfolio of field reporting products (Flash Update, Situation Report and Humanitarian Bulletin) by moving out of static PDFs and consolidating into a single online format. It will be more dynamic, visual, and analytical. The platform will save users' time by automating distribution and design.</p>
+        <p>As the system develops further, it will be adapted to pull data and information automatically from other platforms, which will promote consistency across products and facilitate access to wider analysis. By moving to modular, online content, OCHA will advance significantly in its humanitarian reporting.</p>
       </section>
       <section class="card card--sitreps">
-        <h2 class="card__title">{{ $t('Recently updated', locale) }}:</h2>
+        <h2 class="card__title">{{ $t('Recently updated', locale) }}</h2>
         <ul class="sitrep-list">
           <li class="sitrep" :key="entry.id" v-for="entry in entries">
             <nuxt-link :to="'/country/' + entry.fields.slug">{{ entry.fields.title }}</nuxt-link>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
         <h2 class="card__title">{{ $t('Recently updated', locale) }}</h2>
         <ul class="sitrep-list">
           <li class="sitrep" :key="entry.id" v-for="entry in entries">
-            <nuxt-link :to="'/country/' + entry.fields.slug">{{ entry.fields.title }}</nuxt-link>
+            <nuxt-link :to="'/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
             <span class="last-updated">{{ $t('Last updated', locale) }}: <time :datetime="entry.fields.dateUpdated">{{ $moment(entry.fields.dateUpdated).locale(locale).format('ll') }}</time></span>
           </li>
         </ul>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -76,7 +76,7 @@
   }
   .sitrep {
     list-style-type: none;
-    margin: 0;
+    margin: 0 0 .5rem 0;
     padding: 0;
   }
   .last-updated {


### PR DESCRIPTION
Just a few fixes to spruce things up:

* SitReps are not bunched up so tight.
* restored the original formatting we were using during the ol' Markdown days
* Added trailing slashes to the URLs in the SitRep list which plays nicer with statically generated URLs

![dsr-53-cosmetics](https://user-images.githubusercontent.com/254753/49503176-23c96d00-f877-11e8-8b08-dba2ba49dc45.gif)
