### PR TITLE
DSR-71: artificial delay for truncated Article height calc

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -78,6 +78,27 @@
       }
     },
 
+    methods: {
+      computeArticleHeight() {
+        // Do some client-side manipulation of the Articles to expose a read-more
+        // button on some entries. We calculate the height of the article as
+        // rendered in browser then truncate when it exceeds a certain height.
+        let article = this.$refs['article'];
+        let articleImg = this.$refs['articleImg'];
+
+        // Set the article's min-height to the height of the image
+        this.articleMinHeight = (!!articleImg) ? Math.max(articleImg.height, this.articleMinHeight) : this.articleMinHeight;
+
+        // If the truncated article text will be sufficiently longer than the
+        // accompanying image or the minimum defined in data(), then we apply
+        // the 'Read More' treatment.
+        if (article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)) {
+          this.articleHeight = article.clientHeight;
+          this.isExpandable = true;
+        }
+      }
+    },
+
     created() {
       // Any custom render-methods would go here.
       const richOptions = {};
@@ -85,22 +106,9 @@
     },
 
     mounted() {
-      // Do some client-side manipulation of the Articles to expose a read-more
-      // button on some entries. We calculate the height of the article as
-      // rendered in browser then truncate when it exceeds a certain height.
-      let article = this.$refs['article'];
-      let articleImg = this.$refs['articleImg'];
-
-      // Set the article's min-height to the height of the image
-      this.articleMinHeight = (!!articleImg) ? Math.max(articleImg.height, this.articleMinHeight) : this.articleMinHeight;
-
-      // If the truncated article text will be sufficiently longer than the
-      // accompanying image or the minimum defined in data(), then we apply
-      // the 'Read More' treatment.
-      if (article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)) {
-        this.articleHeight = article.clientHeight;
-        this.isExpandable = true;
-      }
+      // When component mounts, we need to wait for any potential images to load
+      // before trying to calculate the truncated article size.
+      setTimeout(this.computeArticleHeight, 500);
     }
   }
 </script>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -1,5 +1,3 @@
-<template></template>
-
 <script>
   export default {
     computed: {
@@ -23,5 +21,3 @@
     }
   }
 </script>
-
-<style lang="scss"></style>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-71

This approach seems to work nicely provided the connection is fast enough. We can set this higher based on some experimentation but in my local testing (which still uses images from Contentful) this was enough to get the height right without revealing the resize when I scroll immediately.