### PR TITLE
DSR-101: PDF output should be more dense

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -246,7 +246,10 @@
   //
   // Print layout
   //
-  // Many styles from Snap are duplicated here in case someone uses native print.
+  // While capturing PNG or PDF we need non-interactive elements:
+  //
+  // * Ensure text content is totally visible
+  // * Don't render read-more buttons.
   //
   @media print {
     .article__image {
@@ -279,7 +282,6 @@
   //
   // * Ensure text content is totally visible
   // * Don't render read-more buttons.
-  //
   //
   .snap--png,
   .snap--pdf {

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -178,7 +178,6 @@
       grid-template-columns: 1fr 1fr 1fr;
       grid-gap: 1rem;
       margin-bottom: 1rem;
-      page-break-after: always;
     }
 
     .section--primary .card {
@@ -286,8 +285,14 @@
   .section--primary {
     border-bottom: 1px solid #ddd;
   }
+
   .section--everythingElse {
-    page-break-before: always;
+    /**
+     * DSR-101: we want content to flow immediately after Key sections instead
+     * of breaking to the second page. Uncomment to restore page-break and have
+     * Article content begin on page 2.
+     */
+    /*page-break-before: always;*/
   }
   .section--everythingElse .card:last-child {
     border-bottom: 0;


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-101

Articles now start on page 1 immediately following Key sections. When images are present, their appearance on page 1 is dependent on their dimensions physically fitting the vertical space available below Key sections. When space does not permit, the image will appear on page two, allowing Article text to inhabit all available space on page 1.

