### PR TITLE
DSR-111: send cookies along with PNG/PDF Snap requests

### DIFF
--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -33,7 +33,16 @@
         // biggest layout caused by 1164px-wide window. So use 1163 as a minimum
         // and when the actual width is smaller, we'll use current window.
         const windowWidth = Math.min(1163, window.innerWidth);
-        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=png&width=${windowWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.selector)}&user=ocha&pass=dev`;
+
+        // In order to localize the CardHeader and CardFooter, pass our current
+        // cookies which include the active locale setting. To see how this is
+        // picked up and handled by SitRep during a Snap:
+        //
+        // @see middleware/i18n.js
+        const cookies = document.cookie;
+
+        // Final query that we're passing to Snap Service.
+        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=png&width=${windowWidth}&height=${window.innerHeight}&selector=${encodeURIComponent(this.selector)}&user=ocha&pass=dev&cookies=${encodeURIComponent(cookies)}`;
       },
 
       filename() {

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -30,7 +30,14 @@
 
     computed: {
       snapRequest() {
-        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=pdf&media=print&logo=ocha&headerTitle=${encodeURIComponent(this.title.toUpperCase())}&headerSubtitle=${encodeURIComponent(this.subtitle)}&headerDescription=${encodeURIComponent(this.description)}&user=ocha&pass=dev`;
+        // In order to localize the CardHeader and CardFooter, pass our current
+        // cookies which include the active locale setting. To see how this is
+        // picked up and handled by SitRep during a Snap:
+        //
+        // @see middleware/i18n.js
+        const cookies = document.cookie;
+
+        return `${this.snapEndpoint}?url=${encodeURIComponent(this.sitRepUrl)}&output=pdf&media=print&logo=ocha&headerTitle=${encodeURIComponent(this.title.toUpperCase())}&headerSubtitle=${encodeURIComponent(this.subtitle)}&headerDescription=${encodeURIComponent(this.description)}&user=ocha&pass=dev&cookies=${encodeURIComponent(cookies)}`;
       },
 
       filename() {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-111

PR modifies Snaps to send cookies along with the request. It integrates with SitRep's `middleware/i18n.js` which — among other methods — reads cookies to determine what language to use for the UI. End result is localized PNG/PDF downloads!
