### PR TITLE
DSR-86: handle failed calls to FTS

### DIFF
--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -49,7 +49,7 @@
         const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
         // If we failed to fetch FTS Data along the way, return nothing and our
-        // template will display an error.
+        // template will display a prepared error message.
         if (!plan) {
           return [];
         }

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -3,11 +3,11 @@
     <CardHeader />
     <h2 class="card__title">{{ $t('Funding', locale) }}</h2>
     <div class="figures clearfix">
-      <figure v-if="ftsData.length > 0" v-for="figure in ftsData" :key="figure.sys.id">
+      <figure v-if="ftsData.length" v-for="figure in ftsData" :key="figure.sys.id">
         <span class="data">{{ figure.fields.financial }}</span>
         <figcaption>{{ figure.fields.caption }}</figcaption>
       </figure>
-      <div v-if="ftsData.length === 0" class="figures-none">
+      <div v-if="!ftsData.length" class="figures-none">
         {{ $t('Financial data could not be found.', locale) }}
         <br><br>
       </div>

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -3,12 +3,13 @@
     <CardHeader />
     <h2 class="card__title">{{ $t('Funding', locale) }}</h2>
     <div class="figures clearfix">
-      <figure v-if="ftsData" v-for="figure in ftsData" :key="figure.sys.id">
+      <figure v-if="ftsData.length > 0" v-for="figure in ftsData" :key="figure.sys.id">
         <span class="data">{{ figure.fields.financial }}</span>
         <figcaption>{{ figure.fields.caption }}</figcaption>
       </figure>
-      <div v-else class="figures-none">
+      <div v-if="ftsData.length === 0" class="figures-none">
         {{ $t('Financial data could not be found.', locale) }}
+        <br><br>
       </div>
     </div>
     <a :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
@@ -45,7 +46,13 @@
       },
 
       ftsData() {
-        const plan = this.content.filter(plan => plan.id === this.ftsPlanId)[0];
+        const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
+
+        // If we failed to fetch FTS Data along the way, return nothing and our
+        // template will display an error.
+        if (!plan) {
+          return [];
+        }
 
         // The structure mimics Contentful JSON API so that our template above
         // doesn't have to be duplicated based on input data.

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -118,7 +118,8 @@
       fetchAsyncData({env, slug, store}).then((response) => {
         // Update the client-side model with fresh API responses.
         this.entry = response.entry;
-        this.ftsData = response.ftsData;
+        // Only update FTS when the server-side data wasn't loaded.
+        this.ftsData = (this.ftsData.length) ? this.ftsData : response.ftsData;
       });
     },
   }

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -144,13 +144,15 @@
               username: process.env.tmpBasicAuthUser,
               password: process.env.tmpBasicAuthPass,
             }
-          }).then(response => response.data)
+          })
+          .then(response => response.data)
+          .catch(console.error)
         : axios({
             url: '/v2/fts/flow/plan/overview/progress/2018',
             method: 'GET',
           })
           .then(response => response.data)
-          .catch(console.error)
+          .catch(console.warn)
     ]).then(([entries, ftsData]) => {
 
       // For client-side, update our store with the fresh data.
@@ -162,8 +164,8 @@
 
       return {
         entry: entries.items[0],
-        ftsData: ftsData.data.plans,
-      }
+        ftsData: ftsData && ftsData.data && ftsData.data.plans || [],
+      };
     }).catch(console.error)
   }
 </script>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-86

For whatever the reason (404, 500, timeout, etc), when we do not receive data from FTS we need to handle it without blowing our site up. This can happen on both the server during static generation, and also on the client as a visitor browses between pages.

Before, when we couldn't get data from FTS we just logged the error to console and did not even gracefully recover in the template. Now, when the data fails to come back we display a message informing the user of the problem.

This should fix navigations, direct page loads, and static generations. In cases where the statically generated site was successful, but a future direct-visit fails to query client-side, we also bail out and maintain the hard-coded response from the static file.

A future optimization would be to stuff the response in the Vuex store, where we can constantly check it without re-querying the website. But for now I've left all the logic as is, for the most part only touching the template.