### PR TITLE
DSR-111: do a client-side check for locale cookie

### DIFF
--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -72,6 +72,18 @@
       return {}
     },
 
+    methods: {
+      // Modifications to original SO include better variable names, plus guard
+      // against lack of `document` since this code also gets invoked during our
+      // static generation (it's only for client-side JS).
+      //
+      // @see https://stackoverflow.com/a/25490531
+      getCookieValue(name) {
+        var val = (typeof document !== 'undefined') ? document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)') : false;
+        return val ? val.pop() : '';
+      },
+    },
+
     // We use the object populated by asyncData here. It might be empty at first
     // but we can guard against that with a conditional.
     head() {
@@ -106,6 +118,17 @@
     asyncData({env, params, store}) {
       const slug = params.slug;
       return fetchAsyncData({env, slug, store});
+    },
+
+    // Before we assemble this page, check the cookies for a stored locale. If
+    // we find one, we'd prefer to render this page in that language and should
+    // notify the other components by modifying the client-side Vuex store.
+    created() {
+      const cookieVal = this.getCookieValue('locale');
+
+      if (cookieVal) {
+        this.$store.commit('SET_LANG', cookieVal);
+      }
     },
 
     // In cases where HTML response contained stale content, our second call to


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-111

There was a blunder involved with #109 which led me to believe the site would load the correct language when it would in fact not do that whatsoever. The `npm run dev` command does dynamically-generated SSR but our production does statically-generated SSR with EN as our default language. I did not test the original PR with statically-generated files. 😳 

I have added a client-side check for the user's cookies which switches the language before mounting all the components on SitRep pages. It adds a pretty substantial re-render in to the initial operations to show the page, and will show english until the code gets to checking cookies. However the content of the page will always be in the intended language, and this only affects translated strings running through `$t()` in the Vue components.

Sadly, even on local there is a perceptible delay and you can see the language change. I briefly toyed with a CSS animation to fade the content in, obscuring the language switch. I thought it was detrimental overall. If this flash-of-english ends up bothering enough parties, it might be the straw that forces the camel's backend to be dynamically generated.

_&lt;sidenote>alternatively we could add the locale into the URLs themselves, statically generating each variation. That's a future discussion with a couple other implications &lt;/sidenote>_

### Testing the PR

I wanted to test this with due diligence, and no test is truly a success without failure first. So I ran `npm run generate`, fired up browser-sync and pointed it at the `dist/` directory as a static file server. I used our `dev` branch as a control and made sure I always got English anytime I refreshed the page (even after picking French in the dropdown). Similarly, the Snaps were always English on `dev`.

Then I checked this branch out, ran `npm run generate` again, and got the behavior described above: page refreshes briefly show english but ultimately display the user's cookied language. Snaps also returned with the locale of choice.