### PR TITLE
DSR-113 Privacy and copyright footer links

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -12,8 +12,8 @@
       <p class="text"><abbr title="United Nations Office for the Coordination of Humanitarian Affairs">OCHA</abbr> coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.</p>
     </div>
     <ul class="footer-menu">
-      <li><a :href="$t('Privacy policy URL', locale)" target="_blank" rel="noopener">{{ $t('Privacy policy', locale) }}</a></li>
-      <li><a :href="$t('Copyright notice URL', locale)" target="_blank" rel="noopener">{{ $t('Copyright notice', locale) }}</a></li>
+      <li><a :href="$t('href-privacy', locale)" target="_blank" rel="noopener">{{ $t('Privacy policy', locale) }}</a></li>
+      <li><a :href="$t('href-copyright', locale)" target="_blank" rel="noopener">{{ $t('Copyright notice', locale) }}</a></li>
     </ul>
   </footer>
 </template>

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -11,15 +11,23 @@
     <div v-else>
       <p class="text"><abbr title="United Nations Office for the Coordination of Humanitarian Affairs">OCHA</abbr> coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.</p>
     </div>
+    <ul class="footer-menu">
+      <li><a :href="$t('Privacy policy URL', locale)" target="_blank" rel="noopener">{{ $t('Privacy policy', locale) }}</a></li>
+      <li><a :href="$t('Copyright notice URL', locale)" target="_blank" rel="noopener">{{ $t('Copyright notice', locale) }}</a></li>
+    </ul>
   </footer>
 </template>
 
 <script>
+  import Global from '~/components/_Global';
+
   export default {
-    props: {
-      'footer': Object,
-    },
-  }
+    mixins: [Global],
+
+      props: {
+        'footer': Object,
+      },
+    }
 </script>
 
 <style lang="scss" scoped>
@@ -64,4 +72,38 @@
       text-decoration: none;
     }
   }
+
+  .footer-menu {
+    list-style: none;
+    margin: 2em 0 0;
+    padding-left: 0;
+  }
+
+  .footer-menu li {
+    display: inline-block;
+    margin: 0 2em 1em 0;
+  }
+
+  .footer-menu a {
+    border-bottom: 1px solid transparent;
+    color: #666;
+    text-transform: uppercase;
+    text-decoration: none;
+
+    @media print {
+      text-transform: unset;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+
+    @media print {
+      &:after {
+        content:" <" attr(href) "> ";
+      }
+    }
+  }
+
 </style>

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,0 +1,41 @@
+# Locales and Translations
+
+Each file in this directory represents one language offering translatable strings for the codebase. The default language in the codebase is English, and
+all translation keys should use the exact phrase as it appears in English.
+
+Throughout the codebase you'll see `$t('string', locale)` or sometimes prefixed by JavaScript's `this` keyword. The rules follow Vue 2.x conventions, but essentially: the templates do NOT require `this`, but JavaScript methods and functions DO require `this.$t()`.
+
+The conventions are as follows:
+
+- Human-readable text should be sent as it would be output normally
+- Machine-info such as HTML attributes should be lowercase, separated by dashes.
+
+```html
+<!--
+  Example:
+  * One attribute pointing to a localized URL
+  * One human-readable translation string
+-->
+<a :href="$t('href-privacy', locale)">{{ $t('Privacy policy', locale) }}</a>
+```
+
+With that given template, the translations will be as follows:
+
+```js
+// English: en.js
+export default {
+  'Privacy policy': 'Privacy policy',
+  'href-privacy': 'https://www.un.org/en/sections/about-website/privacy-notice/',
+}
+
+// French: fr.js
+export default {
+  'Privacy policy': 'Confidentialité de l\'information',
+  'href-privacy': 'https://www.un.org/fr/sections/about-website/privacy-notice/',
+}
+
+```
+
+English will — as a rule — always contain identical key/value pairs. When a translation for another language is missing, do NOT enter internally-facing words such as "French, missing translation" or something similar.
+
+Any new strings need to be added to our Google Sheet for officially-approved translations. If it's considered ok, in the future we'll just link to it here but for now ping the DSR Flowdock since this repo is open-source.

--- a/locales/en.js
+++ b/locales/en.js
@@ -33,9 +33,9 @@ export default {
 
   // AppFooter
   'Privacy policy': 'Privacy policy',
-  'Privacy policy URL': 'http://www.un.org/en/sections/about-website/privacy-notice',
+  'href-privacy': 'https://www.un.org/en/sections/about-website/privacy-notice/',
   'Copyright notice': 'Copyright notice',
-  'Copyright notice URL': 'https://www.un.org/en/sections/about-website/copyright/index.html',
+  'href-copyright': 'https://www.un.org/en/sections/about-website/copyright/index.html',
 
   // Homepage
   'About this site': 'About this site',

--- a/locales/en.js
+++ b/locales/en.js
@@ -31,6 +31,12 @@ export default {
   'Email': 'Email',
   'Download': 'Download',
 
+  // AppFooter
+  'Privacy policy': 'Privacy policy',
+  'Privacy policy URL': 'http://www.un.org/en/sections/about-website/privacy-notice',
+  'Copyright notice': 'Copyright notice',
+  'Copyright notice URL': 'https://www.un.org/en/sections/about-website/copyright/index.html',
+
   // Homepage
   'About this site': 'About this site',
   'Recently updated': 'Recently updated',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -31,6 +31,12 @@ export default {
   'Email': 'Email',
   'Download': 'Télécharger',
 
+  // AppFooter
+  'Privacy policy': 'Privacy policy',
+  'Privacy policy URL': 'http://www.un.org/fr/sections/about-website/privacy-notice',
+  'Copyright notice': 'Copyright notice',
+  'Copyright notice URL': 'https://www.un.org/fr/sections/about-website/copyright/index.html',
+
   // Homepage
   'About this site': 'A propos de ce site',
   'Recently updated': 'Récemment mis à jour',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -33,9 +33,9 @@ export default {
 
   // AppFooter
   'Privacy policy': 'Privacy policy',
-  'Privacy policy URL': 'http://www.un.org/fr/sections/about-website/privacy-notice',
+  'href-privacy': 'https://www.un.org/fr/sections/about-website/privacy-notice/',
   'Copyright notice': 'Copyright notice',
-  'Copyright notice URL': 'https://www.un.org/fr/sections/about-website/copyright/index.html',
+  'href-copyright': 'https://www.un.org/fr/sections/about-website/copyright/index.html',
 
   // Homepage
   'About this site': 'A propos de ce site',


### PR DESCRIPTION
1. Since this is to display on all pages, the UL is outside the "related links" conditional div.
2. [Translations for the two links and their associated URL](https://github.com/UN-OCHA/reports-site/compare/dsr-113-footer-links?expand=1#diff-009425b4759624e828c30d11c94db76bR15). This might be going too far. The rationale is based on the URLs including the language (eg. https://www.un.org/en/... and https://www.un.org/fr/...)
3. There are [placeholders for the translated links](https://github.com/UN-OCHA/reports-site/compare/dsr-113-footer-links?expand=1#diff-a6c47b7bb79867cbde1d10582942f87bR35) but I did not include proper fr strings. 
@rupl If you see fit, please add [Privacy policy](https://github.com/UN-OCHA/reports-site/compare/dsr-113-footer-links?expand=1#diff-a6c47b7bb79867cbde1d10582942f87bR35) and [Copyright notice](https://github.com/UN-OCHA/reports-site/compare/dsr-113-footer-links?expand=1#diff-a6c47b7bb79867cbde1d10582942f87bR37) to the spreadsheet
I notice they are translated in the titles of the French pages on [un.org](http://www.un.org/fr/sections/about-website/copyright/index.html) but I didn't want to assume anything.
4. I followed the links-in-content convention for print for now. Anchors [display their URL](https://github.com/UN-OCHA/reports-site/compare/dsr-113-footer-links?expand=1#diff-009425b4759624e828c30d11c94db76bR102)
![sitrep-ukraine-footer-print](https://user-images.githubusercontent.com/1835923/50337557-c8071100-0511-11e9-93f2-f47b36a1af2c.png)

### End result

Home desktop:
![sitrep-home-footer-desktop](https://user-images.githubusercontent.com/1835923/50337572-d7865a00-0511-11e9-9cf8-62633c0f0e0f.png)

Home mobile:
![sitrep-ukraine-footer-mobile](https://user-images.githubusercontent.com/1835923/50337575-d81ef080-0511-11e9-8670-7629f861059d.png)

Sitrep desktop:
![sitrep-ukraine-footer-desktop](https://user-images.githubusercontent.com/1835923/50337574-d81ef080-0511-11e9-8382-711273f476b9.png)

Sitrep mobile:
![sitrep-home-footer-mobile](https://user-images.githubusercontent.com/1835923/50337573-d81ef080-0511-11e9-8423-b247e301ba9e.png)
