### PR TITLE
DSR-132: show timestamps on cards

### DIFF
--- a/app.html
+++ b/app.html
@@ -13,6 +13,15 @@
         position: relative;
       }
 
+      @media print {
+        .card {
+          box-shadow: none;
+          border-radius: 0;
+          border-bottom: 1px solid #ddd;
+          padding: 0 0 1rem 0;
+        }
+      }
+
       .card__title {
         margin-bottom: 1rem;
         color: #444;
@@ -25,13 +34,12 @@
         font-family: "Roboto Condensed", sans-serif;
       }
 
-      @media print {
-        .card {
-          box-shadow: none;
-          border-radius: 0;
-          border-bottom: 1px solid #ddd;
-          padding: 0 0 1rem 0;
-        }
+      .card__time-ago {
+        display: inline-block;
+        margin-left: .5em;
+        opacity: .8;
+        font-weight: 400;
+        text-transform: none;
       }
     </style>
     <script>

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -80,28 +80,6 @@
           return this.isExpanded ? this.articleHeight + 'px' : this.articleMinHeight + 'px';
         }
       },
-
-      // How many minutes since the Flash Update was published?
-      timeAgoInMinutes() {
-        return this.$moment(this.updatedAt).diff(this.$moment(), 'minutes') / -1;
-      },
-
-      // Format the duration since Flash Update was published.
-      formatTimeAgo() {
-        let duration = this.timeAgoInMinutes;
-        let units = (duration === 1) ? 'minute' : 'minutes';
-
-        if (duration > 1440) {
-          duration = Math.floor(duration / 1440);
-          units = (duration === 1) ? 'day' : 'days';
-        }
-        else if (duration > 60) {
-          duration = Math.floor(duration / 60);
-          units = (duration === 1) ? 'hour' : 'hours';
-        }
-
-        return duration + ' ' + this.$t(`${units} ago`, this.locale);
-      },
     },
 
     methods: {
@@ -143,14 +121,6 @@
   .card__title {
     display: block;
     margin-bottom: 1rem;
-  }
-
-  .card__time-ago {
-    display: inline-block;
-    margin-left: .5em;
-    opacity: .8;
-    font-weight: 400;
-    text-transform: none;
   }
 
   .article__title {

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -1,7 +1,10 @@
 <template>
   <article class="card card--article article clearfix" :id="cssId">
     <CardHeader />
-    <span class="card__title">{{ $t(content.fields.sectionHeading, locale) }}</span>
+    <span class="card__title">
+      {{ $t(content.fields.sectionHeading, locale) }}
+      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+    </span>
     <div class="article__content" :class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__image" v-if="content.fields.image">
         <figure>
@@ -59,6 +62,7 @@
         isExpandable: false,
         isExpanded: false,
         richBody: '',
+        updatedAt: this.content.sys.updatedAt,
       };
     },
 
@@ -75,7 +79,29 @@
         } else {
           return this.isExpanded ? this.articleHeight + 'px' : this.articleMinHeight + 'px';
         }
-      }
+      },
+
+      // How many minutes since the Flash Update was published?
+      timeAgoInMinutes() {
+        return this.$moment(this.updatedAt).diff(this.$moment(), 'minutes') / -1;
+      },
+
+      // Format the duration since Flash Update was published.
+      formatTimeAgo() {
+        let duration = this.timeAgoInMinutes;
+        let units = (duration === 1) ? 'minute' : 'minutes';
+
+        if (duration > 1440) {
+          duration = Math.floor(duration / 1440);
+          units = (duration === 1) ? 'day' : 'days';
+        }
+        else if (duration > 60) {
+          duration = Math.floor(duration / 60);
+          units = (duration === 1) ? 'hour' : 'hours';
+        }
+
+        return duration + ' ' + this.$t(`${units} ago`, this.locale);
+      },
     },
 
     methods: {
@@ -117,6 +143,14 @@
   .card__title {
     display: block;
     margin-bottom: 1rem;
+  }
+
+  .card__time-ago {
+    display: inline-block;
+    margin-left: .5em;
+    opacity: .8;
+    font-weight: 400;
+    text-transform: none;
   }
 
   .article__title {

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -3,7 +3,7 @@
     <CardHeader />
     <span class="card__title">
       {{ $t('Flash Update', locale) }}
-      <span class="card__time-ago">{{ formatTimeAgo }}</span>
+      <span class="card__time-ago">({{ formatTimeAgo }})</span>
     </span>
     <div class="flash-update__content" :class="{ 'flash-update__content--has-image': content.fields.image }">
       <div class="flash-update__image" v-if="content.fields.image">
@@ -52,28 +52,6 @@
     computed: {
       cssId() {
         return 'cf-' + this.content.sys.id;
-      },
-
-      // How many minutes since the Flash Update was published?
-      timeAgoInMinutes() {
-        return this.$moment(this.updatedAt).diff(this.$moment(), 'minutes') / -1;
-      },
-
-      // Format the duration since Flash Update was published.
-      formatTimeAgo() {
-        let duration = this.timeAgoInMinutes;
-        let units = (duration === 1) ? 'minute' : 'minutes';
-
-        if (duration > 1440) {
-          duration = Math.floor(duration / 1440);
-          units = (duration === 1) ? 'day' : 'days';
-        }
-        else if (duration > 60) {
-          duration = Math.floor(duration / 60);
-          units = (duration === 1) ? 'hour' : 'hours';
-        }
-
-        return duration + ' ' + this.$t(`${units} ago`, this.locale);
       },
 
       // Determine if we should show the Flash Update at all based on the number

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -1,7 +1,10 @@
 <template>
   <article class="card card--keyMessages key-messages" :id="cssId">
     <CardHeader />
-    <h2 class="card__title">{{ $t('Key Messages', locale) }}</h2>
+    <h2 class="card__title">
+      {{ $t('Key Messages', locale) }}
+      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+    </h2>
     <div class="key-messages__area">
       <ul class="message-list">
         <li :key="message.sys.id" v-for="message in messages" class="message">
@@ -31,6 +34,17 @@
     props: {
       'messages': Array,
       'image': Object,
+    },
+
+    data() {
+      return {
+        // updatedAt is the first index of the sorted array of timestamps.
+        updatedAt: this.messages.map((msg) => {
+          return msg.sys.updatedAt
+        }).sort((b, a) => {
+          return a < b ? -1 : (a > b ? 1 : 0);
+        })[0],
+      }
     },
 
     computed: {

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -1,12 +1,36 @@
 <script>
   export default {
     computed: {
+      // Get list of locales
       locales() {
         return this.$store.state.locales;
       },
 
+      // Get current locale
       locale() {
         return this.$store.state.locale;
+      },
+
+      // How many minutes since the Entry was published?
+      timeAgoInMinutes() {
+        return this.$moment(this.updatedAt).diff(this.$moment(), 'minutes') / -1;
+      },
+
+      // Format the duration since the Entry was published.
+      formatTimeAgo() {
+        let duration = this.timeAgoInMinutes;
+        let units = (duration === 1) ? 'minute' : 'minutes';
+
+        if (duration > 1440) {
+          duration = Math.floor(duration / 1440);
+          units = (duration === 1) ? 'day' : 'days';
+        }
+        else if (duration > 60) {
+          duration = Math.floor(duration / 60);
+          units = (duration === 1) ? 'hour' : 'hours';
+        }
+
+        return duration + ' ' + this.$t(`${units} ago`, this.locale);
       },
     },
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-132

Re-using the Flash Update timestamp code across Articles and Key Messages. Moved most logic into the Global mixin so any future timestamping should go smoothly and with less manual setup.

![dsr-132-timestamps](https://user-images.githubusercontent.com/254753/51267614-24801380-198c-11e9-89ad-079684bc1b12.png)
