### PR TITLE
OPS-5309: preview environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ CTF_CDA_ACCESS_TOKEN=0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklm
 
 They will be copied to `.contentful.json` during the docker build step (see below).
 
+## Contentful Preview environments
+
+When the `CTF_HOST` AND `CTF_CDA_PREVIEW_TOKEN` environment variables are present, the app will configure itself to display all edits and new entries immediately, regardless of whether they have been published.
+
 ## Docker setup/development
 
 ```bash

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,9 +4,10 @@ const api = require('./.contentful.json');
 // These allow us to query Contentful and get all of our valid URLs.
 const contentful = require('contentful');
 const client = contentful.createClient({
+  host: api.CTF_HOST,
   space: api.CTF_SPACE_ID,
   environment: api.CTF_ENVIRONMENT,
-  accessToken: api.CTF_CDA_ACCESS_TOKEN,
+  accessToken: api.CTF_CDA_PREVIEW_TOKEN || api.CTF_CDA_ACCESS_TOKEN,
 });
 
 module.exports = {
@@ -14,9 +15,11 @@ module.exports = {
   // Environment variables
   //
   env: {
+    CTF_HOST: api.CTF_HOST || 'cdn.contentful.com',
     CTF_SPACE_ID: api.CTF_SPACE_ID,
     CTF_ENVIRONMENT: api.CTF_ENVIRONMENT || 'master',
     CTF_CDA_ACCESS_TOKEN: api.CTF_CDA_ACCESS_TOKEN,
+    CTF_CDA_PREVIEW_TOKEN: api.CTF_CDA_PREVIEW_TOKEN,
     baseUrl: api.BASE_URL || 'https://reports.unocha.org',
     tmpBasicAuthUser: api.BASIC_AUTH_USER || '',
     tmpBasicAuthPass: api.BASIC_AUTH_PASS || '',

--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -3,9 +3,10 @@ const contentful = require('contentful');
 // use default environment config for convenience
 // these will be set via `env` property in nuxt.config.js
 const config = {
+  host: process.env.CTF_HOST || 'cdn.contentful.com',
   space: process.env.CTF_SPACE_ID,
   environment: process.env.CTF_ENVIRONMENT || 'master',
-  accessToken: process.env.CTF_CDA_ACCESS_TOKEN
+  accessToken: process.env.CTF_CDA_PREVIEW_TOKEN || process.env.CTF_CDA_ACCESS_TOKEN,
 }
 
 // export `createClient` to use it in page components


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/OPS-5309

We want editors to be able to preview their edits, so I'm modifying how we consume our environment variables to ensure that when `CTF_CDA_PREVIEW_TOKEN` is present, it is used as the `accessToken`.

Local testing went as follows:

1. Setup my `.contentful.json` to not have preview token, and `CTF_HOST` set to the default — browsing around the site shows only published content
2. Setup my `.contentful.json` to have `CTF_HOST=preview.contentful.com` and `CTF_CDA_PREVIEW_TOKEN` is present — browsing around displays unpublished edits or even new, unpublished entries.

Let's give this a whirl on stage and see if we can get our preview content!