### PR TITLE
DSR-129: hide emails in SSR

### DIFF
--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -4,7 +4,7 @@
     <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
       <span class="job-title">{{ contact.fields.jobTitle }}</span><br>
-      <a class="email" :href="'mailto:' + contact.fields.email">{{ contact.fields.email }}</a>
+      <a class="email" :href="'mailto:' + hideEmail ? 'no-bots@example.com' : contact.fields.email">{{ hideEmail ? 'no-bots@example.com' : contact.fields.email }}</a>
       <br><br>
     </address>
   </section>
@@ -20,6 +20,18 @@
 
     props: {
       'content': Array,
+    },
+
+    data() {
+      return {
+        // SSR should hide emails from crawlers.
+        hideEmail: true,
+      }
+    },
+
+    beforeMount() {
+      // CSR should reveal emails to browsers with JS.
+      this.hideEmail = false;
     },
   }
 </script>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-129

Attempt to hide the emails a little bit and at least require Vue to be booted before they are displayed. The `window.__NUXT__` object still holds them in the clear so maybe this change isn't effective, but it's at least removing them from the `mailto:` prefix in the HTML response.