### PR TITLE
DSR-132: localize timestamps in french

### DIFF
--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -30,7 +30,12 @@
           units = (duration === 1) ? 'hour' : 'hours';
         }
 
-        return duration + ' ' + this.$t(`${units} ago`, this.locale);
+        // This is done in two steps. Our translations are supplied with the
+        // literal string `#` in them, so we first translate then replace
+        // with the dynamic value of #. That substitution could also be
+        // localized if we want to maintain a list.
+        const value = /\#/gi;
+        return this.$t(`# ${units} ago`, this.locale).replace(value, duration);
       },
     },
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -85,8 +85,16 @@ export default {
   'day ago': 'day ago',
   'days ago': 'days ago',
 
-  // Sharing
+  // Snap strings
   'Read the latest from COUNTRY\'s Situation Report': 'Read the latest from COUNTRY\'s Situation Report',
   'Date of Creation': 'Date of Creation',
   'Date': 'Date',
+
+  // Timestamps
+  '# minute ago': '# minute ago',
+  '# minutes ago': '# minutes ago',
+  '# hour ago': '# hour ago',
+  '# hours ago': '# hours ago',
+  '# day ago': '# day ago',
+  '# days ago': '# days ago',
 }

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -89,4 +89,12 @@ export default {
   'Read the latest from COUNTRY\'s Situation Report': 'COUNTRY: lire la dernière mise à jour du rapport de situation',
   'Date of Creation': 'Date de création',
   'Date': 'Date',
+
+  // Timestamps
+  '# minute ago': 'Il y a # minute',
+  '# minutes ago': 'Il y a # minutes',
+  '# hour ago': 'Il y a # heure',
+  '# hours ago': 'Il y a # heures',
+  '# day ago': 'Il y a # jour',
+  '# days ago': 'Il y a # jours',
 }


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-132

I realized while doing some other work that the timestamps weren't displaying in French. This PR takes care of it, translating into French to begin with. I re-used the social sharing logic which uses a placeholder to translate the strings (in this case a `#`), then substitutes the placeholder afterward.

<img width="1217" alt="dsr-132-timestamp-translated" src="https://user-images.githubusercontent.com/254753/51563075-f8afd280-1e50-11e9-82a4-3c73c5edfed7.png">
