### PR TITLE
DSR-134: RichText preview

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -106,7 +106,7 @@
     created() {
       // Any custom render-methods would go here.
       const richOptions = {};
-      this.richBody = documentToHtmlString(this.content.fields.body, richOptions);
+      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, richOptions) : '';
     },
 
     mounted() {

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -104,9 +104,7 @@
     },
 
     created() {
-      // Any custom render-methods would go here.
-      const richOptions = {};
-      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, richOptions) : '';
+      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, this.renderOptions) : '';
     },
 
     mounted() {

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -2,7 +2,10 @@
   <section class="card card--cluster cluster" :id="cssId">
     <CardHeader />
 
-    <h2 class="card__title">{{ $t('Cluster Status', locale) }}</h2>
+    <h2 class="card__title">
+      {{ $t('Cluster Status', locale) }}
+      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+    </h2>
     <div class="cluster__meta clearfix">
       <h3 class="cluster__title">{{ content.fields.clusterName }}</h3>
       <div class="figures clearfix" v-if="content.fields.clusterFigures">
@@ -48,18 +51,19 @@
       'content': Object,
     },
 
-    computed: {
-      cssId() {
-        return 'cf-' + this.content.sys.id;
-      }
-    },
-
     data() {
       return {
         richNeeds: '',
         richResponse: '',
         richGaps: '',
+        updatedAt: this.content.sys.updatedAt,
       };
+    },
+
+    computed: {
+      cssId() {
+        return 'cf-' + this.content.sys.id;
+      }
     },
 
     created() {

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -67,12 +67,9 @@
     },
 
     created() {
-      // Any custom render-methods would go here.
-      const richOptions = {};
-
-      this.richNeeds = this.content.fields.clusterNeeds ? documentToHtmlString(this.content.fields.clusterNeeds, richOptions) : '';
-      this.richResponse = this.content.fields.clusterResponse ? documentToHtmlString(this.content.fields.clusterResponse, richOptions) : '';
-      this.richGaps = this.content.fields.clusterGaps ? documentToHtmlString(this.content.fields.clusterGaps, richOptions) : '';
+      this.richNeeds = this.content.fields.clusterNeeds ? documentToHtmlString(this.content.fields.clusterNeeds, this.renderOptions) : '';
+      this.richResponse = this.content.fields.clusterResponse ? documentToHtmlString(this.content.fields.clusterResponse, this.renderOptions) : '';
+      this.richGaps = this.content.fields.clusterGaps ? documentToHtmlString(this.content.fields.clusterGaps, this.renderOptions) : '';
     }
   }
 </script>

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -66,9 +66,9 @@
       // Any custom render-methods would go here.
       const richOptions = {};
 
-      this.richNeeds = documentToHtmlString(this.content.fields.clusterNeeds, richOptions);
-      this.richResponse = documentToHtmlString(this.content.fields.clusterResponse, richOptions);
-      this.richGaps = documentToHtmlString(this.content.fields.clusterGaps, richOptions);
+      this.richNeeds = this.content.fields.clusterNeeds ? documentToHtmlString(this.content.fields.clusterNeeds, richOptions) : '';
+      this.richResponse = this.content.fields.clusterResponse ? documentToHtmlString(this.content.fields.clusterResponse, richOptions) : '';
+      this.richGaps = this.content.fields.clusterGaps ? documentToHtmlString(this.content.fields.clusterGaps, richOptions) : '';
     }
   }
 </script>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -65,7 +65,7 @@
     created() {
       // Any custom render-methods would go here.
       const richOptions = {};
-      this.richBody = documentToHtmlString(this.content.fields.body, richOptions);
+      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, richOptions) : '';
     },
   }
 </script>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -63,9 +63,7 @@
     },
 
     created() {
-      // Any custom render-methods would go here.
-      const richOptions = {};
-      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, richOptions) : '';
+      this.richBody = this.content.fields.body ? documentToHtmlString(this.content.fields.body, this.renderOptions) : '';
     },
   }
 </script>

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -89,8 +89,7 @@
     },
 
     created() {
-      const richOptions = {};
-      this.richBody = this.content.fields.description ? documentToHtmlString(this.content.fields.description, richOptions) : '';
+      this.richBody = this.content.fields.description ? documentToHtmlString(this.content.fields.description, this.renderOptions) : '';
     },
   }
 </script>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -1,5 +1,12 @@
 <script>
   export default {
+    data() {
+      return {
+        // Options or custom methods for rendering Contentful RichText fields.
+        renderOptions: {},
+      }
+    },
+
     computed: {
       // Get list of locales
       locales() {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-134

Ensure our RichText fields don't crash when rendering missing or empty fields. This is possible because of unvalidated input being rendered on our new Preview URLs. Since Contentful validation only applies when you hit "Publish" in their UI, the preview environment can get into a state where blank fields are rendered.

I also snuck in a timestamp on the Cluster component. I missed it during #125 and #133 