### PR TITLE
DSR-126: more predictable image captions

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -15,7 +15,9 @@
             :alt="content.fields.image.fields.title"
             :width="content.fields.image.fields.file.details.image.width"
             :height="content.fields.image.fields.file.details.image.height">
-          <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
+          <figcaption v-if="content.fields.image.fields.description">
+            {{ content.fields.image.fields.description }}
+          </figcaption>
         </figure>
       </div>
       <div ref="article" class="article__text" :class="{

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -246,10 +246,6 @@ main code {
 
 //—— Captioned Images ——————————————————————————————————————————————————————————
 
-figure {
-  position: relative;
-}
-
 figure img {
   width: 100%;
   height: auto;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -258,27 +258,17 @@ figure img {
   border-radius: 5px;
 }
 
-@media screen {
-  figure img ~ figcaption {
-    position: absolute;
-    right: 0;
-    bottom: 4px;
-    max-width: 80%;
-    padding: .666em 1.333em;
-    background: rgba(0,0,0,0.666);
-    color: white;
-    border-radius: 5px 0 5px 0;
-  }
+figure img ~ figcaption {
+  margin: .25cm;
+  color: #444;
+  background: none;
+  font-size: .9em;
+  font-style: italic;
 }
+
 @media print {
   figure {
     page-break-inside: avoid;
-  }
-  figure img ~ figcaption {
-    margin: .25cm;
-    color: black;
-    background: none;
-    font-style: italic;
   }
 }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-126

Our original image captions were occasionally getting in the way of content when images contained actual information, as opposed to being plain photos. Infographics had legends or other important captioning covered up. On mobile, an especially long caption would exceed the height of an image and overflow upward, an especially awkward visual bug.

We disabled the `screen` styles and opted for `print` on all media, since they don't overlay and just sit below the image.