### PR TITLE
DSR-97: Responsive images for all components

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -9,12 +9,37 @@
     <div class="article__content" :class="{ 'article__content--has-image': content.fields.image }">
       <div class="article__image" v-if="content.fields.image">
         <figure>
-          <img
-            ref="articleImg"
-            :src="content.fields.image.fields.file.url"
-            :alt="content.fields.image.fields.title"
-            :width="content.fields.image.fields.file.details.image.width"
-            :height="content.fields.image.fields.file.details.image.height">
+          <picture>
+            <source type="image/webp"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=webp 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=webp 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=webp 1239w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 1220px) 413px" />
+
+            <source type="image/jpeg"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=jpg 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=jpg 1239w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 1220px) 413px" />
+
+            <img
+              ref="articleImg"
+              class="interactive__img"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg'"
+              :alt="content.fields.image.fields.title">
+          </picture>
           <figcaption v-if="content.fields.image.fields.description">
             {{ content.fields.image.fields.description }}
           </figcaption>
@@ -73,6 +98,10 @@
         return 'cf-' + this.content.sys.id;
       },
 
+      secureImageUrl() {
+        return 'https:' + this.content.fields.image.fields.file.url;
+      },
+
       // Allows us to smoothly transition between unknown min-max heights.
       // Returns 'auto' when no transition is necessary.
       getArticleHeight() {
@@ -102,7 +131,19 @@
           this.articleHeight = article.clientHeight;
           this.isExpandable = true;
         }
-      }
+      },
+
+      // Input any width value to get the height as defined by the proportions.
+      // of the image stored in Contentful for this Entry.
+      //
+      // We round to the nearest pixel for you, just plop it in your template.
+      getImageHeight(requestedWidth) {
+        const width = this.content.fields.image.fields.file.details.image.width;
+        const height = this.content.fields.image.fields.file.details.image.height;
+        const ratio = height / width;
+
+        return Math.round(requestedWidth * ratio);
+      },
     },
 
     created() {

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -12,10 +12,10 @@
           <picture>
             <source type="image/webp"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=webp 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=webp 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=webp 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=webp 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=webp 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=webp 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -24,10 +24,10 @@
 
             <source type="image/jpeg"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=jpg 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=jpg 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=jpg 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=jpg 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -37,7 +37,7 @@
             <img
               ref="articleImg"
               class="interactive__img"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">
@@ -131,18 +131,6 @@
           this.articleHeight = article.clientHeight;
           this.isExpandable = true;
         }
-      },
-
-      // Input any width value to get the height as defined by the proportions.
-      // of the image stored in Contentful for this Entry.
-      //
-      // We round to the nearest pixel for you, just plop it in your template.
-      getImageHeight(requestedWidth) {
-        const width = this.content.fields.image.fields.file.details.image.width;
-        const height = this.content.fields.image.fields.file.details.image.height;
-        const ratio = height / width;
-
-        return Math.round(requestedWidth * ratio);
       },
     },
 

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -9,11 +9,37 @@
     <div class="flash-update__content" :class="{ 'flash-update__content--has-image': content.fields.image }">
       <div class="flash-update__image" v-if="content.fields.image">
         <figure>
-          <img
-            :src="content.fields.image.fields.file.url"
-            :alt="content.fields.image.fields.title"
-            :width="content.fields.image.fields.file.details.image.width"
-            :height="content.fields.image.fields.file.details.image.height">
+          <picture>
+            <source type="image/webp"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=webp 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=webp 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=webp 1239w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 1220px) 413px" />
+
+            <source type="image/jpeg"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=jpg 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=jpg 1239w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 1220px) 413px" />
+
+            <img
+              ref="articleImg"
+              class="interactive__img"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg'"
+              :alt="content.fields.image.fields.title">
+          </picture>
           <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
         </figure>
       </div>
@@ -55,10 +81,28 @@
         return 'cf-' + this.content.sys.id;
       },
 
+      secureImageUrl() {
+        return 'https:' + this.content.fields.image.fields.file.url;
+      },
+
       // Determine if we should show the Flash Update at all based on the number
       // of minutes versus the duration field.
       displayFlashUpdate() {
         return (Math.floor(this.timeAgoInMinutes / 60) > this.content.fields.duration) ? false : true;
+      },
+    },
+
+    methods: {
+      // Input any width value to get the height as defined by the proportions.
+      // of the image stored in Contentful for this Entry.
+      //
+      // We round to the nearest pixel for you, just plop it in your template.
+      getImageHeight(requestedWidth) {
+        const width = this.content.fields.image.fields.file.details.image.width;
+        const height = this.content.fields.image.fields.file.details.image.height;
+        const ratio = height / width;
+
+        return Math.round(requestedWidth * ratio);
       },
     },
 

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -12,10 +12,10 @@
           <picture>
             <source type="image/webp"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=webp 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=webp 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=webp 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=webp 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=webp 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=webp 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -24,10 +24,10 @@
 
             <source type="image/jpeg"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826) + '&fm=jpg 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239) + '&fm=jpg 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=jpg 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=jpg 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -37,7 +37,7 @@
             <img
               ref="articleImg"
               class="interactive__img"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">{{ content.fields.image.fields.description }}</figcaption>
@@ -89,20 +89,6 @@
       // of minutes versus the duration field.
       displayFlashUpdate() {
         return (Math.floor(this.timeAgoInMinutes / 60) > this.content.fields.duration) ? false : true;
-      },
-    },
-
-    methods: {
-      // Input any width value to get the height as defined by the proportions.
-      // of the image stored in Contentful for this Entry.
-      //
-      // We round to the nearest pixel for you, just plop it in your template.
-      getImageHeight(requestedWidth) {
-        const width = this.content.fields.image.fields.file.details.image.width;
-        const height = this.content.fields.image.fields.file.details.image.height;
-        const ratio = height / width;
-
-        return Math.round(requestedWidth * ratio);
       },
     },
 

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -28,7 +28,7 @@
                 '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920) + '&fm=webp 1920w'"
               sizes="\
                 calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 6rem - 2rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
                 (min-width: 1220px) calc(1080px - 2rem)" />
 
             <source type="image/jpeg"
@@ -40,7 +40,7 @@
                 '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920) + '&fm=jpg 1920w'"
               sizes="\
                 calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 6rem - 2rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
                 (min-width: 1220px) calc(1080px - 2rem)" />
 
             <img

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -21,11 +21,11 @@
           <picture>
             <source type="image/webp"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=webp 640w,\
-                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960) + '&fm=webp 960w,\
-                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280) + '&fm=webp 1280w,\
-                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920) + '&fm=webp 1920w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=webp 640w,\
+                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=webp 960w,\
+                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=webp 1280w,\
+                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=webp 1920w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -33,11 +33,11 @@
 
             <source type="image/jpeg"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=jpg 640w,\
-                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960) + '&fm=jpg 960w,\
-                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280) + '&fm=jpg 1280w,\
-                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920) + '&fm=jpg 1920w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=jpg 640w,\
+                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=jpg 960w,\
+                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=jpg 1280w,\
+                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=jpg 1920w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -45,7 +45,7 @@
 
             <img
               class="interactive__img"
-              :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>
         </a>
@@ -92,20 +92,6 @@
       },
       secureImageUrl() {
         return 'https:' + this.content.fields.image.fields.file.url;
-      },
-    },
-
-    methods: {
-      // Input any width value to get the height as defined by the proportions.
-      // of the image stored in Contentful for this Entry.
-      //
-      // We round to the nearest pixel for you, just plop it in your template.
-      getImageHeight(requestedWidth) {
-        const width = this.content.fields.image.fields.file.details.image.width;
-        const height = this.content.fields.image.fields.file.details.image.height;
-        const ratio = height / width;
-
-        return Math.round(requestedWidth * ratio);
       },
     },
 

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -14,7 +14,33 @@
       </ul>
       <div class="image-area" v-if="image && typeof image.fields !== 'undefined'">
         <figure>
-          <img class="image" :src="'https:' + image.fields.file.url" :alt="image.fields.title">
+          <picture class="image">
+            <source type="image/webp"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=webp 640w,\
+                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800) + '&fm=webp 800w,\
+                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=webp 1032w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 800px) calc((100vw - 10rem) / 2)\
+                (min-width: 1220px) 515px" />
+
+            <source type="image/jpeg"
+              :srcset="'\
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=jpg 640w,\
+                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800) + '&fm=jpg 800w,\
+                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=jpg 1032w'"
+              sizes="\
+                calc(100vw - 4rem),\
+                (min-width: 600px) calc(100vw - 8rem - 2rem),\
+                (min-width: 800px) calc((100vw - 10rem) / 2)\
+                (min-width: 1220px) 515px" />
+
+            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=jpg'" :alt="image.fields.title">
+          </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
         </figure>
       </div>
@@ -53,7 +79,24 @@
       cssId() {
         return `cf-${this.messages.map((msg) => msg.sys.id).join('_')}`;
       },
-    }
+      secureImageUrl() {
+        return 'https:' + this.image.fields.file.url;
+      },
+    },
+
+    methods: {
+      // Input any width value to get the height as defined by the proportions.
+      // of the image stored in Contentful for this Entry.
+      //
+      // We round to the nearest pixel for you, just plop it in your template.
+      getImageHeight(requestedWidth) {
+        const width = this.image.fields.file.details.image.width;
+        const height = this.image.fields.file.details.image.height;
+        const ratio = height / width;
+
+        return Math.round(requestedWidth * ratio);
+      },
+    },
   }
 </script>
 

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -17,10 +17,10 @@
           <picture class="image">
             <source type="image/webp"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=webp 640w,\
-                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800) + '&fm=webp 800w,\
-                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=webp 1032w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + '&fm=webp 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + '&fm=webp 640w,\
+                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + '&fm=webp 800w,\
+                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=webp 1032w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -29,17 +29,17 @@
 
             <source type="image/jpeg"
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640) + '&fm=jpg 640w,\
-                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800) + '&fm=jpg 800w,\
-                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=jpg 1032w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + '&fm=jpg 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + '&fm=jpg 640w,\
+                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + '&fm=jpg 800w,\
+                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg 1032w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
                 (min-width: 800px) calc((100vw - 10rem) / 2)\
                 (min-width: 1220px) 515px" />
 
-            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032) + '&fm=jpg'" :alt="image.fields.title">
+            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'" :alt="image.fields.title">
           </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
         </figure>
@@ -81,20 +81,6 @@
       },
       secureImageUrl() {
         return 'https:' + this.image.fields.file.url;
-      },
-    },
-
-    methods: {
-      // Input any width value to get the height as defined by the proportions.
-      // of the image stored in Contentful for this Entry.
-      //
-      // We round to the nearest pixel for you, just plop it in your template.
-      getImageHeight(requestedWidth) {
-        const width = this.image.fields.file.details.image.width;
-        const height = this.image.fields.file.details.image.height;
-        const ratio = height / width;
-
-        return Math.round(requestedWidth * ratio);
       },
     },
   }

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -77,7 +77,19 @@
       // the whole page. It's stupid.
       //
       // @see https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
-      noop() {}
+      noop() {},
+
+      // Input any width value to get the height as defined by the proportions.
+      // of the image stored in Contentful for this Entry.
+      //
+      // We round to the nearest pixel for you, just plop it in your template.
+      getImageHeight(requestedWidth, referenceImage) {
+        const width = referenceImage.fields.file.details.image.width;
+        const height = referenceImage.fields.file.details.image.height;
+        const ratio = height / width;
+
+        return Math.round(requestedWidth * ratio);
+      },
     }
   }
 </script>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -71,18 +71,25 @@
     },
 
     methods: {
+      //
       // This handler intentionally left blank in order to facilitate click
       // handling outside the AppHeader > Share component. It uses vue-clickaway
       // but iPhone does not delegate clicks so we set up a blank handler on
       // the whole page. It's stupid.
       //
       // @see https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
+      //
       noop() {},
 
+      //
       // Input any width value to get the height as defined by the proportions.
       // of the image stored in Contentful for this Entry.
       //
-      // We round to the nearest pixel for you, just plop it in your template.
+      // referenceImage must be the full Contentful JSON response for the asset
+      // field you want to use as a ratio calculation
+      //
+      // We round the return value to to the nearest pixel.
+      //
       getImageHeight(requestedWidth, referenceImage) {
         const width = referenceImage.fields.file.details.image.width;
         const height = referenceImage.fields.file.details.image.height;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -254,7 +254,8 @@ figure img {
   border-radius: 5px;
 }
 
-figure img ~ figcaption {
+figure img ~ figcaption,
+figure picture ~ figcaption {
   margin: .25cm;
   color: #444;
   background: none;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -43,6 +43,7 @@ module.exports = {
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { hid: 'manifest', rel: 'manifest', href: '/manifest.json' },
       { hid: 'apple-touch-icon', rel: 'apple-touch-icon', href: '/icons/app-icon_192.png' },
+      { hid: 'ctf-image-preconnect', rel: 'preconnect', href: 'https://images.ctfassets.net' },
       // { rel: 'stylesheet', type: 'text/css', href: '/global.css' },
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "1.7.1",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "1.7.1",
+  "version": "1.12.0",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-97

After #140 introduced the first responsive image I felt compelled to get all the other components on board. With this PR we can truly encourage the editors to upload the absolute highest quality graphics they have on hand, and our code will now pull an appropriate format/size for the device. Components that we updated:

* Key Messages
* Article
* Flash Update

I used the full picture syntax in order to give browsers a chance to select WebP over JPG when they so desire, in addition to various pixel-density and dimension options. The testing results are in the ticket but to summarize the bandwidth reduction (higher is good):

* Desktop: 50%
* Mobile retina screen: 66%
* Mobile non-retina: 90%

The fallback for all images is currently configured to output what is best for IE11 since it's the oldest thing on our official support matrix, and it doesn't support `<picture>` element. So even though IE11 doesn't get the modern benefits of `<picture>`, the intentional resizing of the fallback image is a huge improvement there too!