### PR TITLE
OPS-5270: potential workaround for 401s

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,8 +21,6 @@ module.exports = {
     CTF_CDA_ACCESS_TOKEN: api.CTF_CDA_ACCESS_TOKEN,
     CTF_CDA_PREVIEW_TOKEN: api.CTF_CDA_PREVIEW_TOKEN,
     baseUrl: api.BASE_URL || 'https://reports.unocha.org',
-    tmpBasicAuthUser: api.BASIC_AUTH_USER || '',
-    tmpBasicAuthPass: api.BASIC_AUTH_PASS || '',
   },
   //
   // Global <head> metadata

--- a/pages/country/_slug.vue
+++ b/pages/country/_slug.vue
@@ -167,15 +167,11 @@
       // FTS: fetch all v2 plans.
       (process.server)
         ? axios({
-            url: `${process.env.baseUrl}/v2/fts/flow/plan/overview/progress/2018`,
+            url: `https://reports.unocha.org/v2/fts/flow/plan/overview/progress/2018`,
             method: 'GET',
-            auth: {
-              username: process.env.tmpBasicAuthUser,
-              password: process.env.tmpBasicAuthPass,
-            }
           })
           .then(response => response.data)
-          .catch(console.error)
+          .catch(console.warn)
         : axios({
             url: '/v2/fts/flow/plan/overview/progress/2018',
             method: 'GET',


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/OPS-5270

We have these non-fatal errors during static generation and I'm hoping to get rid of them by switching to our production FTS URL during deploys on all environments. We no longer use the environment-specific baseURL to query FTS.