### PR TITLE
DSR-144: send Content-Length in Snap request

### DIFF
--- a/components/Snap.vue
+++ b/components/Snap.vue
@@ -59,6 +59,11 @@
             url: this.snapRequest,
             method: 'POST',
             responseType: 'arraybuffer',
+            headers: {
+              // We send all params as querystring so the length of our body is
+              // known to be zero.
+              'Content-Length': 0,
+            },
           })
           .then((response) => {
             this.handleSnap(response);


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-144

One more follow-up, even though our HTTP/2 dev environment was fixed by the previous work in this ticket to reduce our encoded whitespace in the querystring params.

This was the advice of the nginx bug and we know it's always zero so why not set it?