### PR TITLE
DSR-119: SitRep default language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reports.unocha.org
 
-Digital Situation Reports for UN OCHA.
+Digital Situation Reports for UN OCHA. Vue+Nuxt produces a [SSR+Hydration architecture](https://developers.google.com/web/updates/2019/02/rendering-on-the-web#rehydration), ensuring that we serve full HTML responses while taking advantage of modern JS tools for client-side interactivity. We use Contentful as our CMS, offloading all data entry responsibilities to a paid service.
 
 ## Nuxt setup/development
 

--- a/_migrations/11-update-sitrep.js
+++ b/_migrations/11-update-sitrep.js
@@ -23,4 +23,20 @@ module.exports = function(migration) {
 
   sitrep
     .changeEditorInterface('language', 'singleLine')
+
+  //
+  // REMOVE the unique validation for the `slug` field. Our custom implementation
+  // of multilingual Entries requires us to provide unique languages amongst
+  // entries with duplicated slugs.
+  //
+  // Ex:
+  // LANG ↴     SLUG ↴
+  //   - /en/country/ukraine/
+  //   - /ru/country/ukraine/
+  //
+  sitrep
+    .editField('slug')
+    .validations([
+      { "unique": false },
+    ])
 };

--- a/_migrations/11-update-sitrep.js
+++ b/_migrations/11-update-sitrep.js
@@ -1,0 +1,26 @@
+module.exports = function(migration) {
+  //
+  // Field: countryCode
+  //
+  const sitrep = migration.editContentType('sitrep')
+
+  sitrep
+    .createField('language')
+      .name('Language')
+      .type('Symbol')
+      .required(true)
+      .disabled(false) // we'll manually disable after data entry
+      .validations([
+        {
+          "regexp": {"pattern": "^[a-zA-Z]{2}$"},
+          "message": "Enter the two-letter language code (ISO 639-1)"
+        }
+      ])
+
+  sitrep
+    .moveField('language')
+    .afterField('countryCode')
+
+  sitrep
+    .changeEditorInterface('language', 'singleLine')
+};

--- a/_migrations/README.md
+++ b/_migrations/README.md
@@ -8,6 +8,12 @@ If necessary, please familiarize yourself with the [Contentful domain model](htt
 - Tutorial: https://www.contentful.com/blog/2017/09/18/using-the-contentful-migration-cli/
 - Official examples: https://github.com/contentful/contentful-migration/tree/master/examples
 
+## Setup
+
+In order to execute migrations on a Space, you need to have a [personal access token](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/personal-access-tokens/personal-access-token). This is separate from the API keys that power our read-only JS app.
+
+The personal access token allows you to execute the migrations. Migrations can read, write, perform modifications to Content Types, and transfer content between Spaces. We are mostly focused on modifications to Content Types when discussing our migrations.
+
 
 ## Executing Migrations
 
@@ -28,6 +34,7 @@ npm run migration -- --space-id 0123456789 --environment-id 'sandbox' _migration
 ```
 
 Note: we are using `npm run migration` because that ensures we all migrate using the same version, as opposed to a globally-installed tool that may or may not support all the features we need.
+
 
 ## Data types
 

--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -15,7 +15,7 @@
           {{ $t('Latest updates', locale) }}
         </li>
         <li class="link link--sitrep" :key="entry.id" v-for="entry in entries">
-          <nuxt-link :to="'/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
+          <nuxt-link :to="'/' + entry.fields.language + '/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
         </li>
         <li v-if="false" class="link link--about">
           <nuxt-link :to="'/about/'">{{ $t('About', locale) }}</nuxt-link>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -199,7 +199,7 @@
     @supports (display: grid) {
       .header {
         display: grid;
-        grid-template-columns: 2fr 218px;
+        grid-template-columns: 2fr 270px;
         grid-gap: 1rem;
       }
 

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -9,7 +9,7 @@
         <figcaption>{{ figure.fields.caption }}</figcaption>
       </figure>
       <div v-if="!ftsData.length" class="figures-none">
-        {{ $t('Financial data could not be found.', locale) }}
+        {{ $t('Funding data could not be found.', locale) }}
         <br><br>
       </div>
     </div>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -97,6 +97,18 @@
 
         return Math.round(requestedWidth * ratio);
       },
+
+      //
+      // Determine whether one of our supported languages is RTL or LTR.
+      //
+      languageDirection(language) {
+        const rtl = [
+          'ar',
+          'he',
+        ];
+
+        return (rtl.includes(language)) ? 'rtl' : 'ltr';
+      },
     }
   }
 </script>

--- a/locales/en.js
+++ b/locales/en.js
@@ -55,7 +55,7 @@ export default {
   'Funding': 'Funding',
   'Requirements': 'Requirements',
   'Progress': 'Progress',
-  'Financial data could not be found.': 'Financial data could not be found.',
+  'Funding data could not be found.': 'Funding data could not be found.',
 
   // Contacts
   'Contacts': 'Contacts',
@@ -80,12 +80,6 @@ export default {
 
   // Flash Updates
   'Flash Update': 'Flash Update',
-  'minute ago': 'minute ago',
-  'minutes ago': 'minutes ago',
-  'hour ago': 'hour ago',
-  'hours ago': 'hours ago',
-  'day ago': 'day ago',
-  'days ago': 'days ago',
 
   // Videos
   'Video': 'Video',

--- a/locales/en.js
+++ b/locales/en.js
@@ -8,8 +8,6 @@ export default {
   'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
   'Situation Report': 'Situation Report',
   'Situation Reports': 'Situation Reports',
-  'Read more': 'Read more',
-  'Read less': 'Read less',
 
   // Errors
   'No data available.': 'No data available.',
@@ -77,6 +75,8 @@ export default {
   'Media': 'Media',
   'Trends': 'Trends',
   'Visuals and Data': 'Visuals And Data',
+  'Read more': 'Read more',
+  'Read less': 'Read less',
 
   // Flash Updates
   'Flash Update': 'Flash Update',

--- a/locales/es.js
+++ b/locales/es.js
@@ -1,0 +1,106 @@
+export default {
+  // System
+  'lang': 'es',
+  'lang-name': 'Español',
+
+  // Global
+  'UN OCHA': 'UN OCHA',
+  'UN Office for the Coordination of Humanitarian Affairs': 'Oficina de la ONU para la coordinación de asuntos humanitarios',
+  'Situation Report': 'Informe de situación',
+  'Situation Reports': 'Informes de situación',
+
+  // Errors
+  'No data available.': 'No hay datos disponibles',
+  'Page not found': 'Página no encontrada',
+  'We want to help you find the information you are looking for.': 'Deseamos ayudarle a encontrar la información que está buscando.',
+  'Here are some of OCHA\'s latest Situation Reports to help you get back on track:': 'Estos son algunos de los informes de situación más recientes de OCHA:',
+
+  // AppBar
+  'Toggle menu': 'Menú toggle',
+  'Home': 'Inicio',
+  'Latest updates': 'Últimas actualizaciones',
+  'About': 'Acerca de',
+  'OCHA Services': 'Servicios de OCHA',
+
+  // AppHeader
+  'Last updated': 'Última actualización',
+  'Subscribe': 'Suscribirse',
+  'Share': 'Compartir',
+  'Email': 'Correo electrónico',
+  'Download': 'Descargar',
+  'Archive': 'Archivo',
+
+  // AppFooter
+  'Privacy policy': 'Política de confidencialidad',
+  'href-privacy': 'https://www.un.org/es/sections/about-website/privacy-notice/',
+  'Copyright notice': 'Derechos de autor',
+  'href-copyright': 'https://www.un.org/es/sections/about-website/copyright/index.html',
+  'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.': 'Coordinar la respuesta global a las emergencias, salvando vidas y protegiendo a las personas en situaciones de crisis humanitarias.  En OCHA, abogamos por una acción humanitaria honrada y eficaz por parte de todos y para todos.',
+
+  // Homepage
+  'About this site': 'Acerca del sitio',
+  'Recently updated': 'Recién actualizado',
+  'The Digital Situation Report aims to simplify OCHA\'s current portfolio of field reporting products (Flash Update, Situation Report and Humanitarian Bulletin) by moving out of static PDFs and consolidating into a single online format. It will be more dynamic, visual, and analytical. The platform will save users\' time by automating distribution and design.': 'El Informe de Situación Digital tiene como objetivo simplificar la cartera actual de productos de información de OCHA sobre el terreno (Actualización Rápida, Informe de Situación y Boletín Humanitario), al salir de los PDFs estáticos y consolidarlos en un solo formato en línea. Será más dinámico, visual y analítico. La plataforma ayudará a los usuarios a ahorrar tiempo al automatizar la distribución y el diseño.',
+  'As the system develops further, it will be adapted to pull data and information automatically from other platforms, which will promote consistency across products and facilitate access to wider analysis. By moving to modular, online content, OCHA will advance significantly in its humanitarian reporting.': 'A medida que el sistema se desarrolle, se adaptará para extraer datos e información automáticamente de otras plataformas, lo que promoverá la coherencia entre los productos y facilitará el acceso a un análisi más amplio. Al pasar a contenido modular en línea, OCHA estará realizando un avance significativo en sus informes humanitarios.',
+
+  // Key Messages
+  'Key Messages': 'Mensajes clave',
+
+  // Key Figures
+  'Key Figures': 'Cifras clave',
+
+  // Funding
+  'Funding': 'Financiamiento',
+  'Requirements': 'Requisitos',
+  'Progress': 'Progreso',
+  'Funding data could not be found.': 'Los datos de financiamiento no se pudieron descargar.',
+
+  // Contacts
+  'Contacts': 'Contactos',
+
+  // Clusters
+  'Cluster Status': 'Estado del cluster',
+  'Needs': 'Necesidades',
+  'Response': 'Respuesta',
+  'Gaps': 'Necesidades no cubiertas',
+
+  // Articles
+  'Access': 'Acceso',
+  'Analysis': 'Análisis',
+  'Background': 'Contexto',
+  'Coordination': 'Coordinación',
+  'Emergency Response': 'Respuesta de emergencia',
+  'Feature': 'Destacado',
+  'Forecast': 'Pronóstico',
+  'Media': 'Medios',
+  'Trends': 'Tendencias',
+  'Visuals and Data': 'Visuales y datos',
+  'Read more': 'Leer más',
+  'Read less': 'Leer menos',
+
+  // Flash Updates
+  'Flash Update': 'Flash Update',
+
+  // Videos
+  'Video': 'Video',
+
+  // Interactives
+  'Interactive': 'Interactivo',
+
+  // Social media
+  'Read the latest from COUNTRY\'s Situation Report': 'Leer la última actualización del informe de situación de COUNTRY',
+
+  // Snap strings
+  'Date of Creation': 'Fecha de creación',
+  'Date': 'Fecha',
+  'Downloaded': 'Descargado el',
+  'Page # of #': 'Página # de #',
+
+  // Timestamps
+  '# minute ago': 'Hace # minuto',
+  '# minutes ago': 'Hace # minutos',
+  '# hour ago': 'Hace # hora',
+  '# hours ago': 'Hace # horas',
+  '# day ago': 'Hace # día',
+  '# days ago': 'Hace # días',
+}

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -55,7 +55,7 @@ export default {
   'Funding': 'Financement',
   'Requirements': 'Conditions requises',
   'Progress': 'Progrès',
-  'Financial data could not be found.': 'Les données sur le financement n\'ont pu être téléchargées.',
+  'Funding data could not be found.': 'Les données sur le financement n\'ont pu être téléchargées.',
 
   // Contacts
   'Contacts': 'Contacts',
@@ -80,12 +80,6 @@ export default {
 
   // Flash Updates
   'Flash Update': 'Flash Info',
-  'minute ago': 'minute ago',
-  'minutes ago': 'minutes ago',
-  'hour ago': 'hour ago',
-  'hours ago': 'hours ago',
-  'day ago': 'day ago',
-  'days ago': 'days ago',
 
   // Videos
   'Video': 'Video',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -5,7 +5,7 @@ export default {
 
   // Global
   'UN OCHA': 'UN OCHA',
-  'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
+  'UN Office for the Coordination of Humanitarian Affairs': 'Bureau de la coordination des affaires humanitaires des Nations Unies',
   'Situation Report': 'Rapport de situation',
   'Situation Reports': 'Rapports de situation',
 
@@ -70,7 +70,7 @@ export default {
   'Background': 'Contexte',
   'Coordination': 'Coordination',
   'Emergency Response': 'Réponse d\'urgence',
-  'Feature': 'Reportage',
+  'Feature': 'Article principal',
   'Forecast': 'Prévisions',
   'Media': 'Médias',
   'Trends': 'Tendances',
@@ -79,10 +79,10 @@ export default {
   'Read less': 'Lire moins',
 
   // Flash Updates
-  'Flash Update': 'Flash Info',
+  'Flash Update': 'Mise à jour éclair',
 
   // Videos
-  'Video': 'Video',
+  'Video': 'Vidéo',
 
   // Interactives
   'Interactive': 'Interactif',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -8,8 +8,6 @@ export default {
   'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
   'Situation Report': 'Rapport de situation',
   'Situation Reports': 'Rapports de situation',
-  'Read more': 'Lire davantage',
-  'Read less': 'Lire moins',
 
   // Errors
   'No data available.': 'Aucune donnée disponible.',
@@ -71,12 +69,14 @@ export default {
   'Analysis': 'Analyse',
   'Background': 'Contexte',
   'Coordination': 'Coordination',
-  'Emergency Response': 'Reponse d\'urgence',
+  'Emergency Response': 'Réponse d\'urgence',
   'Feature': 'Reportage',
   'Forecast': 'Prévisions',
-  'Media': 'Medias',
+  'Media': 'Médias',
   'Trends': 'Tendances',
-  'Visuals and Data': 'Visuels et donnees',
+  'Visuals and Data': 'Visuels et données',
+  'Read more': 'Lire davantage',
+  'Read less': 'Lire moins',
 
   // Flash Updates
   'Flash Update': 'Flash Info',
@@ -85,7 +85,7 @@ export default {
   'Video': 'Video',
 
   // Interactives
-  'Interactive': 'Interactive',
+  'Interactive': 'Interactif',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'COUNTRY: lire la dernière mise à jour du rapport de situation',

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -1,0 +1,106 @@
+export default {
+  // System
+  'lang': 'ru',
+  'lang-name': 'Русский',
+
+  // Global
+  'UN OCHA': 'УКГВ ООН',
+  'UN Office for the Coordination of Humanitarian Affairs': 'Управление ООН по координации гуманитарных вопросов',
+  'Situation Report': 'Оперативная сводка',
+  'Situation Reports': 'Оперативные сводки',
+
+  // Errors
+  'No data available.': 'Нет данных',
+  'Page not found': 'Страница не найдена.',
+  'We want to help you find the information you are looking for.': 'Мы хотим помочь Вам найти нужную информацию.',
+  'Here are some of OCHA\'s latest Situation Reports to help you get back on track:': 'Обратитесь к Оперативным сводкам УКГВ, чтобы быть в курсе последних обновлений',
+
+  // AppBar
+  'Toggle menu': 'Выдвигающееся меню',
+  'Home': 'Главная',
+  'Latest updates': 'Последние обновления',
+  'About': 'Про',
+  'OCHA Services': 'Услуги УКГВ',
+
+  // AppHeader
+  'Last updated': 'Последние обновления',
+  'Subscribe': 'Подписаться',
+  'Share': 'Поделиться',
+  'Email': 'Электронная почта',
+  'Download': 'Загрузить',
+  'Archive': 'Архив',
+
+  // AppFooter
+  'Privacy policy': 'Политика конфиденциальности',
+  'href-privacy': 'https://www.un.org/ru/sections/about-website/privacy-notice/',
+  'Copyright notice': 'Уведомление об авторском праве',
+  'href-copyright': 'https://www.un.org/ru/sections/about-website/copyright/index.html',
+  'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.': 'УКГВ координирует меры реагирования в чрезвычайных ситуациях по всему миру для спасения жизней и защиты людей в условиях гуманитарных кризисов. Мы выступаем за эффективное осуществление гуманитарной деятельности всеми участниками в соответствии с установленными принципами на благо всех сторон.',
+
+  // Homepage
+  'About this site': 'О сайте',
+  'Recently updated': 'Обновлено',
+  'The Digital Situation Report aims to simplify OCHA\'s current portfolio of field reporting products (Flash Update, Situation Report and Humanitarian Bulletin) by moving out of static PDFs and consolidating into a single online format. It will be more dynamic, visual, and analytical. The platform will save users\' time by automating distribution and design.': 'Цель Оперативной сводки в электронном формате –  облегчить работу с рядом отчётов (Экспресс-отчёт, Оперативная сводка, Гуманитарный бюллетень) и перейти от статичных отчётов в формате PDF к единому консолидированному онлайн формату. Такой формат будет более динамичным и наглядным с улучшенной аналитикой. Платформа обеспечит экономию времени пользователей за счёт автоматической рассылки и формирования дизайна документа.',
+  'As the system develops further, it will be adapted to pull data and information automatically from other platforms, which will promote consistency across products and facilitate access to wider analysis. By moving to modular, online content, OCHA will advance significantly in its humanitarian reporting.': 'По мере доработки системы появится возможность автоматической загрузки данных и информации с других платформ, что обеспечит унификацию материалов и доступ для проведения расширенного анализа. Благодаря переходу к модульному онлайн формату представления информации, УКГВ существенно улучшит гуманитарную отчётность.',
+
+  // Key Messages
+  'Key Messages': 'Ключевые положения',
+
+  // Key Figures
+  'Key Figures': 'Ключевые показатели',
+
+  // Funding
+  'Funding': 'Финансирование',
+  'Requirements': 'Требования',
+  'Progress': 'Выполнение',
+  'Funding data could not be found.': 'Данные о финансировании не найдены',
+
+  // Contacts
+  'Contacts': 'Обратная связь',
+
+  // Clusters
+  'Cluster Status': 'Статус кластера',
+  'Needs': 'Потребности',
+  'Response': 'Реагирование',
+  'Gaps': 'Пробелы',
+
+  // Articles
+  'Access': 'Доступ',
+  'Analysis': 'Анализ',
+  'Background': 'Контекст',
+  'Coordination': 'Координация',
+  'Emergency Response': 'Реагирование на чрезвычайные ситуации',
+  'Feature': 'Тема выпуска',
+  'Forecast': 'Прогноз',
+  'Media': 'СМИ',
+  'Trends': 'Тенденции',
+  'Visuals and Data': 'Графические изображения и данные',
+  'Read more': 'Читать далее',
+  'Read less': 'Свернуть',
+
+  // Flash Updates
+  'Flash Update': 'Экспресс-отчёт',
+
+  // Videos
+  'Video': 'Video',
+
+  // Interactives
+  'Interactive': 'Интерактивная версия',
+
+  // Social media
+  'Read the latest from COUNTRY\'s Situation Report': 'Ознакомтесь с последними данными Оперативной сводки о COUNTRY',
+
+  // Snap strings
+  'Date of Creation': 'Дата создания',
+  'Date': 'Дата',
+  'Downloaded': 'Загружено',
+  'Page # of #': 'Стр. # из #',
+
+  // Timestamps
+  '# minute ago': '# минута назад',
+  '# minutes ago': '# минуты/минут назад',
+  '# hour ago': '# час назад',
+  '# hours ago': '# часа/часов назад',
+  '# day ago': '# день назад',
+  '# days ago': '# дня/дней назад',
+}

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -1,0 +1,102 @@
+export default {
+  // System
+  'lang': 'uk',
+  'lang-name': 'Українська',
+
+  // Global
+  'UN OCHA': 'UN OCHA',
+  'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
+  'Situation Report': 'Оперативне зведення',
+  'Situation Reports': 'Оперативні зведення',
+  'Read more': 'Читати далі',
+  'Read less': 'Згорнути',
+
+  // Errors
+  'No data available.': 'Дані відсутні',
+  'Page not found': 'Сторінку не знайдено.',
+  'We want to help you find the information you are looking for.': 'Ми хочемо допомогти Вам знайти необхідну інформацію.',
+  'Here are some of OCHA\'s latest Situation Reports to help you get back on track:': 'Зверніться до Оперативних зведень УКГС, щоб бути в курсі останніх оновлень',
+
+  // AppBar
+  'Toggle menu': 'Висувне меню',
+  'Home': 'Головна',
+  'Latest updates': 'Останні оновлення',
+  'About': 'Про',
+  'OCHA Services': 'Послуги УКГС',
+
+  // AppHeader
+  'Last updated': 'Останнє оновлення',
+  'Subscribe': 'Підписатися',
+  'Share': 'Поширити',
+  'Email': 'Електронна пошта',
+  'Download': 'Завантажити',
+  'Archive': 'Archive',
+
+  // AppFooter
+  'Privacy policy': 'Privacy policy',
+  'href-privacy': 'https://www.un.org/en/sections/about-website/privacy-notice/',
+  'Copyright notice': 'Copyright notice',
+  'href-copyright': 'https://www.un.org/en/sections/about-website/copyright/index.html',
+  'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.': 'УКГС координує заходи реагування в надзвичайних ситуаціях по всьому світу заради спасіння життя та захисту людей в умовах гуманітарних криз. Ми підтримуємо ефективне виконання гуманітарної роботи всіма учасниками згідно з узгодженими принципами на користь усіх сторін.',
+
+  // Homepage
+  'About this site': 'Про сайт',
+  'Recently updated': 'Оновлено',
+  'The Digital Situation Report aims to simplify OCHA\'s current portfolio of field reporting products (Flash Update, Situation Report and Humanitarian Bulletin) by moving out of static PDFs and consolidating into a single online format. It will be more dynamic, visual, and analytical. The platform will save users\' time by automating distribution and design.': 'Метою Оперативного зведення в електронному форматі є спростити роботу з низкою звітів (Експрес-звіт, Оперативне зведення, Гуманітарний бюлетень) та перейти від статичних звітів у форматі PDF до єдиного консолідованого онлайн формату. Такий формат буде більш динамічним, наочним та аналітичним. Платформа заощаджуватиме час користувачів завдяки автоматичному відправленню та формуванню дизайну документа.',
+  'As the system develops further, it will be adapted to pull data and information automatically from other platforms, which will promote consistency across products and facilitate access to wider analysis. By moving to modular, online content, OCHA will advance significantly in its humanitarian reporting.': 'Після подальшого доопрацювання системи буде можливість автоматичного завантаження даних та інформації з інших платформ, що сприятиме уніфікації продуктів та забезпечить доступ для поглибленого аналізу. Завдяки переходу до модульного онлайн формату представлення інформації УКГС суттєво покращить гуманітарну звітність',
+
+  // Key Messages
+  'Key Messages': 'Ключові положення',
+
+  // Key Figures
+  'Key Figures': 'Ключові показники',
+
+  // Funding
+  'Funding': 'Фінансування',
+  'Requirements': 'Вимоги',
+  'Progress': 'Виконання',
+  'Funding data could not be found.': 'Дані щодо фінансування не завантажуються',
+
+  // Contacts
+  'Contacts': 'Зворотний зв’язок',
+
+  // Clusters
+  'Cluster Status': 'Статус кластера',
+  'Needs': 'Потреби',
+  'Response': 'Реагування',
+  'Gaps': 'Прогалини',
+
+  // Articles
+  'Access': 'Access',
+  'Analysis': 'Аналіз',
+  'Background': 'Контекст',
+  'Coordination': 'Coordination',
+  'Emergency Response': 'Emergency Response',
+  'Feature': 'Feature',
+  'Forecast': 'Прогноз',
+  'Media': 'Media',
+  'Trends': 'Trends',
+  'Visuals and Data': 'Visuals And Data',
+
+  // Flash Updates
+  'Flash Update': 'Flash Update',
+
+  // Videos
+  'Video': 'Video',
+
+  // Interactives
+  'Interactive': 'Interactive',
+
+  // Snap strings
+  'Read the latest from COUNTRY\'s Situation Report': 'Дізнайтесь про останні дані Оперативного зведення про COUNTRY',
+  'Date of Creation': 'Date of Creation',
+  'Date': 'Date',
+
+  // Timestamps
+  '# minute ago': '# хвилина тому',
+  '# minutes ago': '# хвилини/хвилин тому',
+  '# hour ago': '# година тому',
+  '# hours ago': '# години/годин тому',
+  '# day ago': '# день тому',
+  '# days ago': '# дня/дні тому',
+}

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -8,8 +8,6 @@ export default {
   'UN Office for the Coordination of Humanitarian Affairs': 'UN Office for the Coordination of Humanitarian Affairs',
   'Situation Report': 'Оперативне зведення',
   'Situation Reports': 'Оперативні зведення',
-  'Read more': 'Читати далі',
-  'Read less': 'Згорнути',
 
   // Errors
   'No data available.': 'Дані відсутні',
@@ -33,10 +31,10 @@ export default {
   'Archive': 'Archive',
 
   // AppFooter
-  'Privacy policy': 'Privacy policy',
-  'href-privacy': 'https://www.un.org/en/sections/about-website/privacy-notice/',
-  'Copyright notice': 'Copyright notice',
-  'href-copyright': 'https://www.un.org/en/sections/about-website/copyright/index.html',
+  'Privacy policy': 'Політика конфіденційності ',
+  'href-privacy': 'https://www.un.org/ru/sections/about-website/privacy-notice/',
+  'Copyright notice': 'Повідомлення про авторські права',
+  'href-copyright': 'https://www.un.org/ru/sections/about-website/copyright/index.html',
   'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.': 'УКГС координує заходи реагування в надзвичайних ситуаціях по всьому світу заради спасіння життя та захисту людей в умовах гуманітарних криз. Ми підтримуємо ефективне виконання гуманітарної роботи всіма учасниками згідно з узгодженими принципами на користь усіх сторін.',
 
   // Homepage
@@ -77,6 +75,8 @@ export default {
   'Media': 'Media',
   'Trends': 'Trends',
   'Visuals and Data': 'Visuals And Data',
+  'Read more': 'Читати далі',
+  'Read less': 'Згорнути',
 
   // Flash Updates
   'Flash Update': 'Flash Update',
@@ -87,10 +87,14 @@ export default {
   // Interactives
   'Interactive': 'Interactive',
 
-  // Snap strings
+  // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Дізнайтесь про останні дані Оперативного зведення про COUNTRY',
-  'Date of Creation': 'Date of Creation',
-  'Date': 'Date',
+
+  // Snap strings
+  'Date of Creation': 'Дата створення',
+  'Date': 'Дата',
+  'Downloaded': 'Завантажено',
+  'Page # of #': 'С. # з #',
 
   // Timestamps
   '# minute ago': '# хвилина тому',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -53,7 +53,7 @@ module.exports = {
   // Additional modules for our site
   //
   modules: [
-    ['@nuxtjs/moment', ['fr', 'ru', 'uk']],
+    ['@nuxtjs/moment', ['es', 'fr', 'ru', 'uk']],
   ],
   //
   // Router

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,7 +55,7 @@ module.exports = {
   // Additional modules for our site
   //
   modules: [
-    ['@nuxtjs/moment', ['fr']],
+    ['@nuxtjs/moment', ['fr', 'uk']],
   ],
   //
   // Router

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -53,7 +53,7 @@ module.exports = {
   // Additional modules for our site
   //
   modules: [
-    ['@nuxtjs/moment', ['fr', 'uk']],
+    ['@nuxtjs/moment', ['fr', 'ru', 'uk']],
   ],
   //
   // Router

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,7 +96,7 @@ module.exports = {
         })
         .then((res) => {
           return res.items.map((page) => {
-            return route = '/country/' + page.fields.slug;
+            return route = '/' + page.fields.language + '/country/' + page.fields.slug;
           });
         });
     }

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -12,7 +12,7 @@
         <br>
         <ul class="sitrep-list">
           <li class="sitrep" :key="entry.id" v-for="entry in entries">
-            <nuxt-link :to="'/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
+            <nuxt-link :to="'/' + entry.fields.language + '/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
             <span class="last-updated">{{ $t('Last updated', locale) }}: <time :datetime="entry.fields.dateUpdated">{{ $moment(entry.fields.dateUpdated).locale(locale).format('D MMM YYYY') }}</time></span>
           </li>
         </ul>

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -51,6 +51,16 @@
       }
     },
 
+    head() {
+      return {
+        // Language settings determined by user language preference.
+        htmlAttrs: {
+          lang: this.locale,
+          dir: this.languageDirection(this.locale),
+        },
+      };
+    },
+
     // `env` is available in the context object
     asyncData({env, params, store}) {
       return Promise.all([

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -69,7 +69,7 @@
 
     // Validate the country slug using this function.
     validate({params}) {
-      return typeof params.slug === 'string';
+      return typeof params.slug === 'string' && typeof params.lang === 'string';
     },
 
     // Set up empty objects that will be populated by asyncData.
@@ -122,7 +122,8 @@
     // both SSR and client-side navigations.
     asyncData({env, params, store}) {
       const slug = params.slug;
-      return fetchAsyncData({env, slug, store});
+      const lang = params.lang;
+      return fetchAsyncData({env, lang, slug, store});
     },
 
     // Before we assemble this page, check the cookies for a stored locale. If
@@ -141,9 +142,10 @@
     mounted() {
       const env = {};
       const slug = this.$route.params.slug;
+      const lang = this.$route.params.lang;
       const store = this.$store;
 
-      fetchAsyncData({env, slug, store}).then((response) => {
+      fetchAsyncData({env, lang, slug, store}).then((response) => {
         // Update the client-side model with fresh API responses.
         this.entry = response.entry;
         // Only update FTS when the server-side data wasn't loaded.
@@ -155,13 +157,14 @@
   // In order to fetch data both during asyncData() and at other times of our
   // own choosing, we have our own custom function which is defined outside
   // our export.
-  function fetchAsyncData({env, slug, store}) {
+  function fetchAsyncData({env, lang, slug, store}) {
     return Promise.all([
       // Contentful: fetch single Entry by slug
       client.getEntries({
         'include': 4,
         'content_type': active_content_type,
         'fields.slug': slug,
+        'fields.language': lang,
       }),
 
       // FTS: fetch all v2 plans.
@@ -353,4 +356,3 @@
   }
 }
 </style>
-

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -87,6 +87,16 @@
         var val = (typeof document !== 'undefined') ? document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)') : false;
         return val ? val.pop() : '';
       },
+
+      // Determine whether one of our supported languages is RTL or LTR.
+      languageDirection(language) {
+        const rtl = [
+          'ar',
+          'he',
+        ];
+
+        return (rtl.includes(language)) ? 'rtl' : 'ltr';
+      },
     },
 
     // We use the object populated by asyncData here. It might be empty at first
@@ -100,6 +110,12 @@
       return {
         // %s is the default site title. In our case the name of the website.
         titleTemplate: `${pageTitle} | %s`,
+
+        // Language settings determined by a field within each SitRep.
+        htmlAttrs: {
+          lang: this.entry.fields.language,
+          dir: this.languageDirection(this.entry.fields.language),
+        },
 
         // @see https://nuxtjs.org/api/pages-head/
         meta: [

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -87,16 +87,6 @@
         var val = (typeof document !== 'undefined') ? document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)') : false;
         return val ? val.pop() : '';
       },
-
-      // Determine whether one of our supported languages is RTL or LTR.
-      languageDirection(language) {
-        const rtl = [
-          'ar',
-          'he',
-        ];
-
-        return (rtl.includes(language)) ? 'rtl' : 'ltr';
-      },
     },
 
     // We use the object populated by asyncData here. It might be empty at first

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -238,6 +238,31 @@
 
 @media print and (min-width: 10cm),
        screen and (min-width: 760px) {
+  /**
+   * No CSS Grid support
+   *
+   * Given the landscape and browser trends, there is only one definition for
+   * large screens lacking CSS Grid. We're defining a float layout with some
+   * height units to ensure uniformity.
+   */
+  .card--keyMessages {
+    float: none;
+    width: 100%;
+  }
+
+  .card--keyFigures,
+  .card--keyFinancials,
+  .card--contacts {
+    float: left;
+    width: calc(100% / 3 - (2rem / 3));
+    min-height: 240px;
+    margin-right: 1rem;
+  }
+
+  .card--contacts {
+    margin-right: 0;
+  }
+
   @supports (display: grid) {
     .section--primary {
       display: grid;
@@ -249,7 +274,8 @@
     }
 
     .section--primary .card {
-      margin-bottom: 0;
+      width: auto;
+      margin: 0;
     }
 
     .card--keyMessages {
@@ -271,32 +297,6 @@
 
 /*
 @media screen and (min-width: 1164px) {
-  /**
-   * No CSS Grid support
-   *
-   * Given the landscape and browser trends, there is only one definition for
-   * large screens lacking CSS Grid. We're defining a float layout with some
-   * height units to ensure uniformity.
-   * /
-  .card--keyMessages {
-    float: left;
-    width: 73%;
-    width: calc(75% - 1rem);
-    height: 90vh;
-    margin-right: 1rem;
-  }
-
-  .card--keyFigures,
-  .card--keyFinancials,
-  .card--contacts {
-    float: left;
-    width: calc(25%);
-    margin-bottom: 1rem;
-
-    /* This group of three cards must resolve to height of keyMessages * /
-    height: calc(30vh - .666rem);
-  }
-
   /**
    * CSS Grid
    *

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -153,9 +153,14 @@
       }
     },
 
-    // In cases where HTML response contained stale content, our second call to
-    // Contentful/FTS will ensure that everything is up to date.
+    //
+    // Update the page on client-side after initial page load.
+    //
     mounted() {
+      //
+      // In cases where HTML response contained stale content, our second call to
+      // Contentful/FTS will ensure that everything is up to date.
+      //
       const env = {};
       const slug = this.$route.params.slug;
       const lang = this.$route.params.lang;
@@ -167,6 +172,15 @@
         // Only update FTS when the server-side data wasn't loaded.
         this.ftsData = (this.ftsData.length) ? this.ftsData : response.ftsData;
       });
+
+      //
+      // In the absence of existing user preference, we want to localize the UI
+      // to the language of the current SitRep
+      //
+      this.$store.commit('SET_LANG', lang);
+
+      // Set a cookie for any full refresh that might occur.
+      document.cookie = `locale=${lang}`;
     },
   }
 

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -259,6 +259,9 @@
     margin-right: 0;
   }
 
+  /**
+   * CSS Grid support
+   */
   @supports (display: grid) {
     .section--primary {
       display: grid;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -52,6 +52,16 @@
       }
     },
 
+    head() {
+      return {
+        // Language settings determined by user language preference.
+        htmlAttrs: {
+          lang: this.locale,
+          dir: this.languageDirection(this.locale),
+        },
+      };
+    },
+
     // `env` is available in the context object
     asyncData({env, params, store}) {
       return Promise.all([

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -95,7 +95,7 @@
     font-style: italic;
   }
 
-  @media (min-width: 760px) {
+  @media (min-width: 960px) {
     .card--intro {
       float: right;
       width: calc(33.333% - 1rem);
@@ -109,7 +109,7 @@
       main {
         display: grid;
         grid-template-areas: "sitreps intro";
-        grid-template-columns: 2fr 3fr;
+        grid-template-columns: 2fr 2fr;
         grid-gap: 1rem;
       }
 
@@ -124,6 +124,12 @@
       .card--sitreps {
         grid-area: sitreps;
       }
+    }
+  }
+
+  @media (min-width: 1080px) {
+    main {
+      grid-template-columns: 2fr 3fr;
     }
   }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
         <h2 class="card__title">{{ $t('Recently updated', locale) }}</h2>
         <ul class="sitrep-list">
           <li class="sitrep" :key="entry.id" v-for="entry in entries">
-            <nuxt-link :to="'/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
+            <nuxt-link :to="'/' + entry.fields.language + '/country/' + entry.fields.slug + '/'">{{ entry.fields.title }}</nuxt-link>
             <span class="last-updated">{{ $t('Last updated', locale) }}: <time :datetime="entry.fields.dateUpdated">{{ $moment(entry.fields.dateUpdated).locale(locale).format('D MMM YYYY') }}</time></span>
           </li>
         </ul>

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 import en from '~/locales/en.js';
 import fr from '~/locales/fr.js';
+import ru from '~/locales/ru.js';
 import uk from '~/locales/uk.js';
 
 Vue.use(VueI18n);
@@ -15,6 +16,7 @@ export default ({ app, store }) => {
     messages: {
       'en': en,
       'fr': fr,
+      'ru': ru,
       'uk': uk,
     }
   });

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 import en from '~/locales/en.js';
 import fr from '~/locales/fr.js';
+import uk from '~/locales/uk.js';
 
 Vue.use(VueI18n);
 
@@ -14,6 +15,7 @@ export default ({ app, store }) => {
     messages: {
       'en': en,
       'fr': fr,
+      'uk': uk,
     }
   });
 

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 import en from '~/locales/en.js';
+import es from '~/locales/es.js';
 import fr from '~/locales/fr.js';
 import ru from '~/locales/ru.js';
 import uk from '~/locales/uk.js';
@@ -15,6 +16,7 @@ export default ({ app, store }) => {
     fallbackLocale: 'en',
     messages: {
       'en': en,
+      'es': es,
       'fr': fr,
       'ru': ru,
       'uk': uk,

--- a/store/index.js
+++ b/store/index.js
@@ -10,6 +10,10 @@ export const state = () => ({
       name: 'Français'
     },
     {
+      code: 'ru',
+      name: 'Русский'
+    },
+    {
       code: 'uk',
       name: 'Українська'
     },

--- a/store/index.js
+++ b/store/index.js
@@ -6,6 +6,10 @@ export const state = () => ({
       name: 'English'
     },
     {
+      code: 'es',
+      name: 'Español'
+    },
+    {
       code: 'fr',
       name: 'Français'
     },

--- a/store/index.js
+++ b/store/index.js
@@ -8,7 +8,11 @@ export const state = () => ({
     {
       code: 'fr',
       name: 'Français'
-    }
+    },
+    {
+      code: 'uk',
+      name: 'Українська'
+    },
   ],
   reportMeta: {
     title: '',


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-119

This PR introduces the ability to set a default language on a SitRep. The URL structure is changing to the following:

```
# template
https://reports.unocha.org/LANG/country/SITREP/

# examples
https://reports.unocha.org/fr/country/burundi/
https://reports.unocha.org/en/country/ukraine/
```

Otherwise, all existing logic/convention remains the same (client-side language detection, static page URLs, static generation, etc)