### PR TITLE
DSR-157: do not display URLs inline on PDFs

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -105,7 +105,7 @@
     }
 
     @media print {
-      &:after {
+      .snap--print-urls &:after {
         content:" <" attr(href) "> ";
       }
     }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -327,11 +327,16 @@ figure picture ~ figcaption {
     widows: 3;
   }
 
-  .rich-text a[href] {
-    text-decoration: none;
+  //
+  // Print URLs during Snaps
+  //
+  .snap--print-urls {
+    .rich-text a[href] {
+      text-decoration: none;
 
-    &::after {
-      content: " <" attr(href) "> ";
+      &::after {
+        content: " <" attr(href) "> ";
+      }
     }
   }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-157

People hated making URLs accessible on printouts. We will hide them.

The Snap Service (or any other JS-capable agent) can re-expose them by adding `.snap--print-urls` to `<html>`