### PR TITLE
Client-side Content-Length is forbidden

### DIFF
--- a/components/Snap.vue
+++ b/components/Snap.vue
@@ -59,11 +59,6 @@
             url: this.snapRequest,
             method: 'POST',
             responseType: 'arraybuffer',
-            headers: {
-              // We send all params as querystring so the length of our body is
-              // known to be zero.
-              'Content-Length': 0,
-            },
           })
           .then((response) => {
             this.handleSnap(response);


### PR DESCRIPTION
I thought this was helping our previous nginx/http2 issue, but it's apparently not even allowed to be set by the client for security reasons. The browser does it automatically before sending request. TIL.

This PR will remove the following console error from the client:

```
# Chrome
Refused to set unsafe header "Content-Length"

# Firefox
Attempt to set a forbidden header was denied: Content-Length
```