### PR TITLE
DSR-163: Articles gracefully handle unpublished images

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -6,8 +6,8 @@
       {{ $t(content.fields.sectionHeading, locale) }}
       <span class="card__time-ago">({{ formatTimeAgo }})</span>
     </span>
-    <div class="article__content" :class="{ 'article__content--has-image': content.fields.image }">
-      <div class="article__image" v-if="content.fields.image">
+    <div class="article__content" :class="{ 'article__content--has-image': articleHasImage }">
+      <div class="article__image" v-if="articleHasImage">
         <figure>
           <picture>
             <source type="image/webp"
@@ -96,6 +96,10 @@
     computed: {
       cssId() {
         return 'cf-' + this.content.sys.id;
+      },
+
+      articleHasImage() {
+        return this.content.fields.image && this.content.fields.image.fields;
       },
 
       secureImageUrl() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "1.12.0",
+  "version": "1.15.2",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-163

I often use preview mode for local development and let this bug slip through because of it. Articles with an unpublished image present were unceremoniously failing to render on our Training environment (and probably elsewhere but it went unreported).

A few more conditionals and we are now checking not only the presence of an image "Link" in Contentful but also that the linked asset actually has a `fields` object that we can use to render. Contentful has hardcoded validation on Image Assets, meaning the `fields` object cannot exist without a valid URL to their CDN, or the checks for individual properties within would be even more thorough.