### PR TITLE
DSR-168: element-invisible overflow

### DIFF
--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <CardActions label="Key Messages" :frag="'#' + cssId" />
+    <CardActions label="Highlights" :frag="'#' + cssId" />
     <CardFooter />
   </article>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -70,6 +70,9 @@ html {
   clip: rect(1px, 1px, 1px, 1px);
   overflow: hidden;
   height: 1px;
+
+  // extra style added to avoid horizontal overflows
+  transform: scale(.1);
 }
 
 //


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-168

I noticed that the Highlights PNG button was causing mobile horizontal overflow. It's annoying because messy thumb swipes turn into messy horizontal or diagonal scrolling. This fix gets us back on track with zero horizontal overflows.

That means scrolling gestures can be performed in a sloppy way, but the results will still be smooth and vertical.

I also noticed that we had a straggler "Key Messages" laying around inside the PNG button for Highlights. Also fixed.