### PR TITLE
DSR-154: avoid rendering JS-powered buttons in static HTML

### DIFF
--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -132,14 +132,15 @@
 
   .btn--toggle {
     position: fixed;
-    top: .5rem;
+    top: 0;
     left: 1rem;
     z-index: 1001;
     width: 2rem;
-    height: 2rem;
+    height: 3rem;
+    padding: .5rem 0;
     border: 0;
     color: white;
-    background: transparent url('/icons/icon--hamburger.svg') center no-repeat;
+    background: #4c8cca url('/icons/icon--hamburger.svg') center no-repeat;
     background-size: contain;
     cursor: pointer;
     transition: transform .25s ease-in-out;
@@ -265,12 +266,12 @@
       input#app-bar__toggle:checked ~ &,
       &.is--expanded {
         width: 23rem;
-        overflow: auto;
+        overflow: hidden;
       }
     }
 
     .btn--toggle {
-      top: 2rem;
+      top: 1.5rem;
     }
 
     .app-bar__content {

--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -1,43 +1,47 @@
 <template>
-  <nav class="app-bar" :class="{ 'is--expanded': isExpanded }" v-on-clickaway="closeMenu">
-    <button class="btn btn--toggle" title="Toggle menu" @click="toggleMenu">
-      <span class="element-invisible">{{ $t('Toggle menu', locale) }}</span>
-    </button>
-    <nuxt-link :to="$i18n.path('')" class="logo-link">
-      <img class="logo" src="/logo--unocha-lockup.svg" :alt="$t('UN Office for the Coordination of Humanitarian Affairs', locale)">
-    </nuxt-link>
-    <div class="app-bar__content">
-      <ul class="main-nav">
-        <li class="link link--home">
-          <nuxt-link :to="$i18n.path('')" @click="closeMenu">{{ $t('Home', locale) }}</nuxt-link>
-        </li>
-        <li class="link link--latest">
-          {{ $t('Latest updates', locale) }}
-        </li>
-        <SitrepList
-          format="compact"
-          :sitreps="sitreps"
-          v-on:close-menu="closeMenu"
-        />
-        <li v-if="false" class="link link--about">
-          <nuxt-link :to="$i18n.path('about/')" @click="closeMenu">{{ $t('About', locale) }}</nuxt-link>
-        </li>
-      </ul>
+  <div v-on-clickaway="closeMenu">
+    <input id="app-bar__toggle" type="checkbox" v-model="isExpanded" class="element-invisible">
+    <label for="app-bar__toggle" class="btn btn--toggle" :aria-label="$t('Toggle menu', locale)"></label>
 
-      <p class="ocha-heading">{{ $t('OCHA Services', locale) }}</p>
-      <ul class="main-nav ocha-services">
-        <li class="link link--fts"><a href="https://fts.unocha.org/" target="_blank" rel="noopener" @click="closeMenu">Financial Tracking Service</a></li>
-        <li class="link link--hdx"><a href="https://data.humdata.org/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian Data Exchange</a></li>
-        <li class="link link--hid"><a href="https://humanitarian.id/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian ID</a></li>
-        <li class="link link--hri"><a href="https://humanitarianresponse.info/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian Response</a></li>
-        <li class="link link--iasc"><a href="https://interagencystandingcommittee.org/" target="_blank" rel="noopener" @click="closeMenu">Inter-Agency Standing Committee</a></li>
-        <li class="link link--ocha"><a href="https://unocha.org/" target="_blank" rel="noopener" @click="closeMenu">OCHA website</a></li>
-        <li class="link link--rw"><a href="https://reliefweb.int/" target="_blank" rel="noopener" @click="closeMenu">ReliefWeb</a></li>
-        <li class="link link--vosocc"><a href="https://vosocc.unocha.org/" target="_blank" rel="noopener" @click="closeMenu">Virtual OSOCC</a></li>
-        <li class="link link--all"><a href="https://www.unocha.org/ocha-digital-services" target="_blank" rel="noopener" @click="closeMenu">See all OCHA services</a></li>
-      </ul>
-    </div>
-  </nav>
+    <nav class="app-bar" :class="{ 'is--expanded': isExpanded }">
+      <nuxt-link :to="$i18n.path('')" class="logo-link">
+        <img class="logo" src="/logo--unocha-lockup.svg" :alt="$t('UN Office for the Coordination of Humanitarian Affairs', locale)">
+      </nuxt-link>
+      <div class="app-bar__content">
+        <ul class="main-nav">
+          <li class="link link--home">
+            <nuxt-link :to="$i18n.path('')" @click="closeMenu">{{ $t('Home', locale) }}</nuxt-link>
+          </li>
+          <no-ssr>
+            <li class="link link--latest">
+              {{ $t('Latest updates', locale) }}
+            </li>
+            <SitrepList
+              format="compact"
+              :sitreps="sitreps"
+              v-on:close-menu="closeMenu"
+            />
+          </no-ssr>
+          <li v-if="false" class="link link--about">
+            <nuxt-link :to="$i18n.path('about/')" @click="closeMenu">{{ $t('About', locale) }}</nuxt-link>
+          </li>
+        </ul>
+
+        <p class="ocha-heading">{{ $t('OCHA Services', locale) }}</p>
+        <ul class="main-nav ocha-services">
+          <li class="link link--fts"><a href="https://fts.unocha.org/" target="_blank" rel="noopener" @click="closeMenu">Financial Tracking Service</a></li>
+          <li class="link link--hdx"><a href="https://data.humdata.org/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian Data Exchange</a></li>
+          <li class="link link--hid"><a href="https://humanitarian.id/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian ID</a></li>
+          <li class="link link--hri"><a href="https://humanitarianresponse.info/" target="_blank" rel="noopener" @click="closeMenu">Humanitarian Response</a></li>
+          <li class="link link--iasc"><a href="https://interagencystandingcommittee.org/" target="_blank" rel="noopener" @click="closeMenu">Inter-Agency Standing Committee</a></li>
+          <li class="link link--ocha"><a href="https://unocha.org/" target="_blank" rel="noopener" @click="closeMenu">OCHA website</a></li>
+          <li class="link link--rw"><a href="https://reliefweb.int/" target="_blank" rel="noopener" @click="closeMenu">ReliefWeb</a></li>
+          <li class="link link--vosocc"><a href="https://vosocc.unocha.org/" target="_blank" rel="noopener" @click="closeMenu">Virtual OSOCC</a></li>
+          <li class="link link--all"><a href="https://www.unocha.org/ocha-digital-services" target="_blank" rel="noopener" @click="closeMenu">See all OCHA services</a></li>
+        </ul>
+      </div>
+    </nav>
+  </div>
 </template>
 
 <script>
@@ -97,6 +101,15 @@
 <style lang="scss" scoped>
   @import '~/assets/Global.scss';
 
+  // To see/debug this checkbox, remove .element-invisible class within template.
+  input#app-bar__toggle {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1001;
+  }
+
   .app-bar {
     position: fixed;
     top: 0;
@@ -107,9 +120,10 @@
     height: 3rem;
     padding: .5rem 1rem;
     background: #4c8cca;
-    transition: height .1666s ease-in-out;
+    transition: height .25s ease-in-out;
     overflow-y: hidden;
 
+    input#app-bar__toggle:checked ~ &,
     &.is--expanded {
       height: 100vh;
       overflow: scroll;
@@ -120,6 +134,7 @@
     position: fixed;
     top: .5rem;
     left: 1rem;
+    z-index: 1001;
     width: 2rem;
     height: 2rem;
     border: 0;
@@ -127,26 +142,23 @@
     background: transparent url('/icons/icon--hamburger.svg') center no-repeat;
     background-size: contain;
     cursor: pointer;
+    transition: transform .25s ease-in-out;
 
     &:focus {
       // animation: btn--toggle 1s ease-in-out 1;
       outline: 0;
     }
-  }
 
-  //
-  // Animation: hamburger toggle
-  //
-  @keyframes btn--toggle {
-    0% {
-      transform: rotate(0deg) scale(1);
-    }
-    6% {
-      transform: rotate(0deg) scale(1.5);
-    }
-    24% {
-      transform: rotate(0deg) scale(1);
-    }
+    //
+    // Nav toggle state
+    //
+    // If we wanted to apply an effect to the button, use this compound selector
+    // to target both no-JS and JS.
+    //
+    // input#app-bar__toggle:checked ~ &,
+    // .is--expanded ~ & {
+    //   transform: rotate(90deg);
+    // }
   }
 
   .logo-link {
@@ -250,6 +262,7 @@
       overflow: hidden;
       transition-property: width;
 
+      input#app-bar__toggle:checked ~ &,
       &.is--expanded {
         width: 23rem;
         overflow: auto;
@@ -266,8 +279,10 @@
       transition: opacity .1666s ease-in-out;
     }
 
+    input#app-bar__toggle:checked,
     .app-bar.is--expanded {
-      .app-bar__content {
+      & ~ .app-bar .app-bar__content,
+      & .app-bar__content {
         opacity: 1;
       }
     }

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -343,9 +343,10 @@
     display: inline-block;
     position: relative;
     text-transform: uppercase;
+    vertical-align: top;
 
     .page--sitrep & {
-      top: -8.5px;
+      top: 6px;
     }
   }
 

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -39,14 +39,16 @@
           :subtitle="$t('Situation Report', locale)"
           :description="$t('Last updated', locale) + ': ' + $moment(updated).locale(locale).format('D MMM YYYY')" />
         <div v-if="share" class="share" :class="{ 'share--is-open': shareIsOpen }">
-          <button class="share__toggle" @click="toggleShare" @touchend="click" v-on-clickaway="closeShare">
-            <span class="element-invisible">{{ $t('Share', locale) }}</span>
-          </button>
-          <div class="share__options card">
-            <a class="share__option share--twitter" v-if="shareUrlTwitter" :href="shareUrlTwitter" target="_blank" rel="noopener">Twitter</a>
-            <a class="share__option share--facebook" v-if="shareUrlFacebook" :href="shareUrlFacebook" target="_blank" rel="noopener">Facebook</a>
-            <a class="share__option share--email" v-if="shareUrlEmail" :href="shareUrlEmail" target="_blank" rel="noopener">{{ $t('Email', locale) }}</a>
-          </div>
+          <no-ssr>
+            <button class="share__toggle" @click="toggleShare" @touchend="click" v-on-clickaway="closeShare">
+              <span class="element-invisible">{{ $t('Share', locale) }}</span>
+            </button>
+            <div class="share__options card">
+              <a class="share__option share--twitter" v-if="shareUrlTwitter" :href="shareUrlTwitter" target="_blank" rel="noopener">Twitter</a>
+              <a class="share__option share--facebook" v-if="shareUrlFacebook" :href="shareUrlFacebook" target="_blank" rel="noopener">Facebook</a>
+              <a class="share__option share--email" v-if="shareUrlEmail" :href="shareUrlEmail" target="_blank" rel="noopener">{{ $t('Email', locale) }}</a>
+            </div>
+          </no-ssr>
         </div>
       </div>
     </div>
@@ -375,6 +377,8 @@
 
   .share {
     display: inline-block;
+    animation: fade-in .3333s ease-out;
+
 
     &__toggle {
       display: inline-block;

--- a/components/SitrepList.vue
+++ b/components/SitrepList.vue
@@ -141,11 +141,16 @@
 
     .sitrep-group__heading {
       display: inline-block;
-      margin: .25rem 0;
-      padding-left: 1.25rem;
+      margin: 0 0 .5rem 0;
+      padding-left: 1.75rem;
       font-size: 1em;
       background-image: url('/icons/icon--location.svg');
       background-position: 0 50%;
+      text-transform: none;
+
+      .wf-loaded & {
+        font-family: "Roboto", sans-serif;
+      }
     }
 
     .sitrep {

--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -1,13 +1,15 @@
 <template>
-  <button
-    class="btn btn--download"
-    :class="{ 'btn--is-active': snapInProgress }"
-    :disabled="snapInProgress"
-    @click="requestSnap">
-    <span class="element-invisible">
-      Save {{ label }} as PNG
-    </span>
-  </button>
+  <no-ssr>
+    <button
+      class="btn btn--download"
+      :class="{ 'btn--is-active': snapInProgress }"
+      :disabled="snapInProgress"
+      @click="requestSnap">
+      <span class="element-invisible">
+        Save {{ label }} as PNG
+      </span>
+    </button>
+  </no-ssr>
 </template>
 
 <script>
@@ -55,6 +57,9 @@
 </script>
 
 <style lang="scss" scoped>
+  .btn {
+    animation: fade-in .3333s ease-out;
+  }
   .btn--download {
     background-image: url('/icons/icon--download.svg');
   }

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -1,13 +1,15 @@
 <template>
-  <button
-    class="btn btn--pdf"
-    :class="{ 'btn--is-active': snapInProgress }"
-    :disabled="snapInProgress"
-    @click="requestSnap">
-    <span class="element-invisible">
-      Save as PDF
-    </span>
-  </button>
+  <no-ssr>
+    <button
+      class="btn btn--pdf"
+      :class="{ 'btn--is-active': snapInProgress }"
+      :disabled="snapInProgress"
+      @click="requestSnap">
+      <span class="element-invisible">
+        Save as PDF
+      </span>
+    </button>
+  </no-ssr>
 </template>
 
 <script>
@@ -153,6 +155,9 @@
 </script>
 
 <style lang="scss" scoped>
+  .btn {
+    animation: fade-in .3333s ease-out;
+  }
   .btn--pdf {
     display: inline-block;
     background-color: transparent;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -398,6 +398,19 @@ figure picture ~ figcaption {
   text-transform: none;
 }
 
+
+//—— Animations—————————————————————————————————————————————————————————————————
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+
 //—— DevTools ——————————————————————————————————————————————————————————————————
 
 pre {


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-154

Nuxt has both statically generated HTML and JS-powered modes. We were displaying all of our JS-powered buttons before the interactivity was possible, leading to occasional confusion in field offices with faltering connections. 

Using this sweet `<no-ssr>` tag to wrap our interactive components, we can avoid showing them until the page has been hydrated by JS.