### PR TITLE
DSR-154: follow-ups

### DIFF
--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -297,6 +297,7 @@
   // Print layout
   //
   @media print {
+    .btn--toggle,
     .app-bar {
       display: none;
     }

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -346,7 +346,8 @@
     vertical-align: top;
 
     .page--sitrep & {
-      top: 6px;
+      height: 32px; // match height of other buttons
+      top: 6px; // nudge for nice vertical alignment
     }
   }
 

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -381,7 +381,6 @@
     display: inline-block;
     animation: fade-in .3333s ease-out;
 
-
     &__toggle {
       display: inline-block;
       background-color: transparent;

--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -60,7 +60,13 @@
   .btn {
     animation: fade-in .3333s ease-out;
   }
+
   .btn--download {
     background-image: url('/icons/icon--download.svg');
+  }
+
+  .btn--is-active {
+    animation: is-active 1s ease-in-out infinite;
+    cursor: wait;
   }
 </style>

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -182,5 +182,6 @@
 
   .btn--is-active {
     cursor: wait;
+    animation: is-active 1s ease-in-out infinite;
   }
 </style>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-154

Bunch of bugfixes and UX improvements:

- PDFs had big ugly nav button when I tested on dev. Gone.
- the languages weren't quite lined up in no-JS mode. fixed.
- PDF/PNG buttons lost their in-progress animation when I added the fade-in for `<no-ssr>` — due to the scoping mechanism in Vue, the generic styles in `default.vue` no longer applied generically. Reapplying on each component restored the animation.