### PR TITLE
DSR-169: localize PDF/PNG button labels

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -63,7 +63,7 @@
       {{ isExpanded ? $t('Read less', locale) : $t('Read more', locale) }}
     </button>
 
-    <CardActions label="Article" :frag="'#' + cssId" />
+    <CardActions :label="content.fields.sectionHeading" :frag="'#' + cssId" />
     <CardFooter />
   </article>
 </template>

--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -6,7 +6,7 @@
       :disabled="snapInProgress"
       @click="requestSnap">
       <span class="element-invisible">
-        Save {{ label }} as PNG
+        {{ buttonLabel }}
       </span>
     </button>
   </no-ssr>
@@ -30,6 +30,12 @@
     },
 
     computed: {
+      buttonLabel() {
+        // Two-step translation. Our translations have the literal string THING
+        // in them, so we swap that word out in a second step.
+        return this.$t('Save THING as PNG', this.locale).replace('THING', this.$t(this.label, this.locale));
+      },
+
       snapRequest() {
         // To deal with some layout issues on some cards, particularly Key Messages
         // we want to render the website at a large size, but not trigger the

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -6,7 +6,7 @@
       :disabled="snapInProgress"
       @click="requestSnap">
       <span class="element-invisible">
-        Save as PDF
+        {{ $t('Save Situation Report as PDF', locale) }}
       </span>
     </button>
   </no-ssr>

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -92,6 +92,10 @@ export default {
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'إقراء آخر تقارير الوضع عن COUNTRY',
 
+  // Card Actions
+  'Save Situation Report as PDF': 'احفظ تقرير الوضع ك PDF',
+  'Save THING as PNG': 'احفظ THING كملف PNG',
+
   // Snap strings
   'Date of Creation': 'تاريخ الإنشاء',
   'Date': 'التاريخ',

--- a/locales/en.js
+++ b/locales/en.js
@@ -92,6 +92,10 @@ export default {
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Read the latest from COUNTRY\'s Situation Report',
 
+  // Card Actions
+  'Save Situation Report as PDF': 'Save Situation Report as PDF',
+  'Save THING as PNG': 'Save THING as PNG',
+
   // Snap strings
   'Date of Creation': 'Date of Creation',
   'Date': 'Date',

--- a/locales/es.js
+++ b/locales/es.js
@@ -92,6 +92,10 @@ export default {
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Leer la última actualización del informe de situación de COUNTRY',
 
+  // Card Actions
+  'Save Situation Report as PDF': 'Save Situation Report as PDF',
+  'Save THING as PNG': 'Save THING as PNG',
+
   // Snap strings
   'Date of Creation': 'Fecha de creación',
   'Date': 'Fecha',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -92,6 +92,10 @@ export default {
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'COUNTRY: lire la dernière mise à jour du rapport de situation',
 
+  // Card Actions
+  'Save Situation Report as PDF': 'Save Situation Report as PDF',
+  'Save THING as PNG': 'Save THING as PNG',
+
   // Snap strings
   'Date of Creation': 'Date de création',
   'Date': 'Date',

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -29,7 +29,7 @@ export default {
   'Email': 'Электронная почта',
   'Download': 'Загрузить',
   'Archive': 'Архив',
-  'Read this Situation Report in a different language:': 'Read this Situation Report in a different language:',
+  'Read this Situation Report in a different language:': 'Ознакомьтесь с Оперативной сводкой на другом языке',
 
   // AppFooter
   'Privacy policy': 'Политика конфиденциальности',
@@ -46,7 +46,7 @@ export default {
 
   // Key Messages
   'Key Messages': 'Ключевые положения',
-  'Highlights': 'Highlights',
+  'Highlights': 'Главное',
 
   // Key Figures
   'Key Figures': 'Ключевые показатели',
@@ -84,13 +84,17 @@ export default {
   'Flash Update': 'Экспресс-отчёт',
 
   // Videos
-  'Video': 'Video',
+  'Video': 'Видео',
 
   // Interactives
   'Interactive': 'Интерактивная версия',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Ознакомтесь с последними данными Оперативной сводки о COUNTRY',
+
+  // Card Actions
+  'Save Situation Report as PDF': 'Сохранить Оперативную сводку в формате PDF',
+  'Save THING as PNG': 'Сохранить THING в формате PNG',
 
   // Snap strings
   'Date of Creation': 'Дата создания',

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -28,8 +28,8 @@ export default {
   'Share': 'Поширити',
   'Email': 'Електронна пошта',
   'Download': 'Завантажити',
-  'Archive': 'Archive',
-  'Read this Situation Report in a different language:': 'Read this Situation Report in a different language:',
+  'Archive': 'Архів',
+  'Read this Situation Report in a different language:': 'Прочитайте це Оперативне зведення іншою мовою',
 
   // AppFooter
   'Privacy policy': 'Політика конфіденційності ',
@@ -46,7 +46,7 @@ export default {
 
   // Key Messages
   'Key Messages': 'Ключові положення',
-  'Highlights': 'Highlights',
+  'Highlights': 'Головне',
 
   // Key Figures
   'Key Figures': 'Ключові показники',
@@ -84,13 +84,17 @@ export default {
   'Flash Update': 'Flash Update',
 
   // Videos
-  'Video': 'Video',
+  'Video': 'Відео',
 
   // Interactives
   'Interactive': 'Interactive',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Дізнайтесь про останні дані Оперативного зведення про COUNTRY',
+
+  // Card Actions
+  'Save Situation Report as PDF': 'Зберегти Оперативне зведення у форматі PDF',
+  'Save THING as PNG': 'Зберегти THING у форматі PNG',
 
   // Snap strings
   'Date of Creation': 'Дата створення',


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-169

The button labels were all frozen to english. This PR cleans them up to be tokenized localizations of whatever is being Snapped (e.g. an Article with label "Emergency Response" is localized in two steps so that the translation output for Arabic ends up being `احفظ الاستجابة للطوارئ كملف PNG`, bidi issues in this comment notwithstanding)