### PR TITLE
DSR-186: video content should never be across two pages in PDF

### DIFF
--- a/components/Video.vue
+++ b/components/Video.vue
@@ -30,6 +30,9 @@
           <button class="video__play"></button>
         </a>
       </div>
+      <div class="video__pdf-link">
+        <p>View this video at: <a :href="videoEmbedLink">{{ videoEmbedLink }}</a></p>
+      </div>
       <div class="video__text">
         <h3 class="video__title">{{ content.fields.title }}</h3>
         <div class="rich-text" v-html="richBody"></div>
@@ -168,12 +171,32 @@
     padding-bottom: 75%; // 4:3
   }
 
+  // Hide PDF link by default. See Snap PDF below.
+  .video__pdf-link {
+    display: none;
+    margin-bottom: 1rem;
+    text-align: center;
+    font-style: italic;
+  }
+
   //
   // Snap: PDF
   //
   .snap--pdf {
+    // Don't allow video thumbnail to be broken across two pages.
     .video {
       page-break-inside: avoid;
+    }
+
+    // Video can't be played in a PDF.
+    .video__play {
+      display: none;
+    }
+
+    // Since the image isn't clickable automatically, print an extra message
+    // containing a plaintext link.
+    .video__pdf-link {
+      display: block;
     }
   }
 </style>

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -167,4 +167,13 @@
   .video--full {
     padding-bottom: 75%; // 4:3
   }
+
+  //
+  // Snap: PDF
+  //
+  .snap--pdf {
+    .video {
+      page-break-inside: avoid;
+    }
+  }
 </style>


### PR DESCRIPTION
## [DSR-186](https://humanitarian.atlassian.net/browse/DSR-186) and [DSR-140](https://humanitarian.atlassian.net/browse/DSR-140)

Short and sweet. Video thumbnails should never break across the page.

Also it should display a clickable link to the video when printing PDF.