### PR TITLE
OPS-5575: lowercase filenames

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -266,8 +266,8 @@ body {
   font-weight: 400;
   src: local('DubaiW23 Regular'),
        local('DubaiW23-Regular'),
-       url('/fonts/dubaiw23-regular.woff') format('woff'),
-       url('/fonts/dubaiw23-regular.woff2') format('woff2');
+       url('/fonts/dubaiw23-regular.woff2') format('woff2'),
+       url('/fonts/dubaiw23-regular.woff') format('woff');
 }
 
 //—— Site Container ————————————————————————————————————————————————————————————

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -255,7 +255,7 @@ body {
   font-weight: 400;
   src: local('NotoKufiArabic Bold'),
        local('NotoKufiArabic-Bold'),
-       url('/fonts/NotoKufiArabic-Bold.ttf') format('woff');
+       url('/fonts/notokufiarabic-bold.ttf') format('woff');
 }
 
 // Dubai Medium
@@ -266,8 +266,8 @@ body {
   font-weight: 400;
   src: local('DubaiW23 Regular'),
        local('DubaiW23-Regular'),
-       url('/fonts/DubaiW23-Regular.woff') format('woff'),
-       url('/fonts/DubaiW23-Regular.woff2') format('woff2');
+       url('/fonts/dubaiw23-regular.woff') format('woff'),
+       url('/fonts/dubaiw23-regular.woff2') format('woff2');
 }
 
 //—— Site Container ————————————————————————————————————————————————————————————


### PR DESCRIPTION
Follow up to #182  — I didn't change the casing of the references to the files. Ironically, it doesn't matter right now whether we do this or not, but the circle of 🐛 would be complete if we DID turn off the casing rule, because without this PR the URLs would again 404 since the files are now lowercase.