### PR TITLE
DSR-197: display funding year accurately for all timezones

### DIFF
--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -111,7 +111,10 @@
       ftsDataYear() {
         const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
-        return plan && this.$moment(plan.startDate).locale(this.locale).format('YYYY');
+        // Using moment caused timezone confusions and installing `tz()` just to
+        // run it one time seemed heavy-handed for what we want. Instead we're
+        // taking the year out of `startDate` and slicing it out of the string.
+        return plan && plan.startDate.substring(0, 4);
       },
     },
 

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -111,10 +111,7 @@
       ftsDataYear() {
         const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
-        // Using moment caused timezone confusions and installing `tz()` just to
-        // run it one time seemed heavy-handed for what we want. Instead we're
-        // taking the year out of `startDate` and slicing it out of the string.
-        return plan && plan.startDate.substring(0, 4);
+        return plan && this.$moment.utc(plan.startDate).locale(this.locale).format('YYYY');
       },
     },
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-197

Using a much simpler way of displaying FTS year. Due to the fTS data sometimes specifying dates that are extremely close to year changes (e.g. `2018-01-01T00:00:00Z`) it was rendering the year incorrectly for folks in timezones west of UTC.