### PR TITLE
DSR-198: protect against un-uploaded, unpublished images in Preview env

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -99,11 +99,11 @@
       },
 
       articleHasImage() {
-        return this.content.fields.image && this.content.fields.image.fields;
+        return this.content.fields.image && this.content.fields.image.fields && this.content.fields.image.fields.file && this.content.fields.image.fields.file.url;
       },
 
       secureImageUrl() {
-        return 'https:' + this.content.fields.image.fields.file.url;
+        return this.articleHasImage && 'https:' + this.content.fields.image.fields.file.url;
       },
 
       // Allows us to smoothly transition between unknown min-max heights.

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -12,7 +12,7 @@
           {{ message.fields.keyMessage }}
         </li>
       </ul>
-      <div class="image-area" v-if="image && typeof image.fields !== 'undefined'">
+      <div class="image-area" v-if="keyMessagesHasImage">
         <figure>
           <picture class="image">
             <source type="image/webp"
@@ -79,6 +79,11 @@
       cssId() {
         return `cf-${this.messages.map((msg) => msg.sys.id).join('_')}`;
       },
+
+      keyMessagesHasImage() {
+        return this.image && this.image.fields && this.image.fields.file && this.image.fields.file.url;
+      },
+
       secureImageUrl() {
         return 'https:' + this.image.fields.file.url;
       },

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -85,7 +85,11 @@
           // Look at the sys.id of the corresponding sitrep and only return matches.
           return fu.fields.relatedSitRep && fu.fields.relatedSitRep.sys.id === this.entry.sys.id;
         });
-      }
+      },
+
+      keyMessagesHasImage() {
+        return this.entry.fields.keyMessagesImage && this.entry.fields.keyMessagesImage.fields && this.entry.fields.keyMessagesImage.fields.file && this.entry.fields.keyMessagesImage.fields.file.url;
+      },
     },
 
     methods: {
@@ -130,7 +134,7 @@
           { hid: 'og-url', property: 'og:url', content: `https://reports.unocha.org/${this.entry.fields.language}/country/${this.entry.fields.slug}/` },
           { hid: 'og-title', property: 'og:title', content: this.entry.fields.title },
           { hid: 'og-desc', property: 'og:description', content: this.entry.fields.keyMessages.map(msg => msg.fields.keyMessage).join(' — ') },
-          { hid: 'og-image', property: 'og:image', content: 'https:' + this.entry.fields.keyMessagesImage.fields.file.url },
+          { hid: 'og-image', property: 'og:image', content: (this.keyMessagesHasImage) ? 'https:' + this.entry.fields.keyMessagesImage.fields.file.url : '' },
         ],
       };
     },


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-198

Hopefully this cuts down on errors during Preview builds in Jenkins. It will also result in fewer 404s on preview environments where there should be some content.