### PR TITLE
DSR-213 / DSR-214 - changes to Contacts

### DIFF
--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -4,7 +4,7 @@
     <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
       <span v-if="contact.fields.jobTitle" class="job-title">{{ contact.fields.jobTitle }}</span>
-      <a class="email" :href="'mailto:' + hideEmail ? 'no-bots@example.com' : contact.fields.email">{{ hideEmail ? 'no-bots@example.com' : contact.fields.email }}</a>
+      <a class="email" :href="'mailto:' + (hideEmail ? 'no-bots@example.com' : contact.fields.email)">{{ hideEmail ? 'no-bots@example.com' : contact.fields.email }}</a>
       <br><br>
     </address>
   </section>
@@ -29,7 +29,7 @@
       }
     },
 
-    beforeMount() {
+    mounted() {
       // CSR should reveal emails to browsers with JS.
       this.hideEmail = false;
     },

--- a/components/Contacts.vue
+++ b/components/Contacts.vue
@@ -3,7 +3,7 @@
     <h3 class="card__title">{{ $t('Contacts', locale) }}</h3>
     <address :key="contact.sys.id" v-for="contact in content" class="card__contact contact">
       <h4 class="name">{{ contact.fields.name }}</h4>
-      <span class="job-title">{{ contact.fields.jobTitle }}</span><br>
+      <span v-if="contact.fields.jobTitle" class="job-title">{{ contact.fields.jobTitle }}</span>
       <a class="email" :href="'mailto:' + hideEmail ? 'no-bots@example.com' : contact.fields.email">{{ hideEmail ? 'no-bots@example.com' : contact.fields.email }}</a>
       <br><br>
     </address>
@@ -44,6 +44,7 @@
   .name {}
 
   .job-title {
+    display: block;
     color: #666;
   }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-213

Some offices don't put job titles on their contact blocks. Our site was rendering weird empty spaces when it was omitted. Fixed. (name has also been made mandatory on CTF side)

## https://humanitarian.atlassian.net/browse/DSR-214

In the process of checking my work, I found another error related to the rendering of email addresses. Our spam protection was not being removed on client side due to an order of ops bug in the original template code.
