### PR TITLE
DSR-212: Visual content-type

### DIFF
--- a/_migrations/14-create-visual.js
+++ b/_migrations/14-create-visual.js
@@ -1,0 +1,126 @@
+module.exports = function(migration) {
+  //
+  // ContentType: visual
+  //
+  const visual = migration.createContentType('visual')
+
+  visual
+    .name('Visual')
+    .description('Embed an infographic or other large visual.')
+
+  //
+  // Field: Title
+  //
+  // machine-name: title
+  //
+  visual
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(false)
+
+  // Set `title` as the Title field in Contentful UI
+  visual
+    .displayField('title')
+
+  //
+  // Field: Description
+  //
+  // machine-name: description
+  //
+  visual
+    .createField('description')
+    .name('Description')
+    .type('RichText')
+    .required(false)
+    .validations([
+      {
+        "nodes": {}
+      },
+      {
+        "enabledMarks": [
+          "bold",
+          "italic",
+          "underline"
+        ],
+        "message": "Only bold, italic, and underline marks are allowed"
+      },
+      {
+        "enabledNodeTypes": [
+          "heading-4",
+          "heading-5",
+          "ordered-list",
+          "unordered-list",
+          "hyperlink"
+        ],
+        "message": "Only heading 4, heading 5, ordered list, unordered list, and link to Url nodes are allowed"
+      }
+    ])
+
+  //
+  // Field: URL
+  //
+  // machine-name: url
+  //
+  visual
+    .createField('url')
+    .name('URL')
+    .type('Symbol')
+    .required(false)
+    .validations([
+      {
+        "regexp": {
+          "pattern": "^(http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$"
+        },
+        "message": "Please enter a URL beginning with HTTP or HTTPS."
+      }
+    ])
+
+  visual
+    .changeEditorInterface('url', 'urlEditor')
+
+  //
+  // Field: image
+  //
+  // machine-name: image
+  //
+  visual
+    .createField('image')
+    .name('Image')
+    .type('Link')
+    .linkType('Asset')
+    .required(true)
+    .validations([
+      {
+        "linkMimetypeGroup": ['image']
+      }
+    ])
+
+  visual
+    .changeEditorInterface('image', 'assetLinkEditor', {
+      helpText: 'Please upload the highest quality image you have available. Files up to 20MB are allowed.',
+    })
+
+  visual
+    .moveField('image').toTheTop()
+
+
+  //
+  // ContentType: sitrep
+  //
+  // We need to add Visual as a possible Entry reference to the "article" field.
+  //
+  const sitrep = migration.editContentType('sitrep')
+
+  sitrep
+    .editField('article', {
+      items: {
+        type: 'Link',
+        linkType: 'Entry',
+        validations: [
+          { linkContentType: ['article', 'clusterInformation', 'interactive', 'video', 'visual'] }
+        ]
+      }
+    })
+    .name('Content')
+};

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -1,0 +1,126 @@
+<template>
+  <article class="card card--visual visual clearfix" :id="cssId">
+    <CardHeader />
+
+    <span class="card__title">
+      {{ $t('Visual', locale) }}
+      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+    </span>
+    <div class="visual__content">
+      <h3 class="visual__title">{{ content.fields.title }}</h3>
+      <div class="visual__image" v-if="content.fields.image">
+        <picture>
+          <source type="image/webp"
+            :srcset="'\
+              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
+              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=webp 640w,\
+              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=webp 960w,\
+              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=webp 1280w,\
+              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=webp 1920w'"
+            sizes="\
+              calc(100vw - 4rem),\
+              (min-width: 600px) calc(100vw - 8rem - 2rem),\
+              (min-width: 1220px) calc(1080px - 2rem)" />
+
+          <source type="image/jpeg"
+            :srcset="'\
+              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
+              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=jpg 640w,\
+              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=jpg 960w,\
+              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=jpg 1280w,\
+              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=jpg 1920w'"
+            sizes="\
+              calc(100vw - 4rem),\
+              (min-width: 600px) calc(100vw - 8rem - 2rem),\
+              (min-width: 1220px) calc(1080px - 2rem)" />
+
+          <img
+            class="visual__img"
+            :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
+            :alt="content.fields.image.fields.title">
+        </picture>
+      </div>
+      <div v-else>
+        <a
+          v-if="content.fields.url"
+          :href="content.fields.url"
+          target="_blank"
+          rel="noopener"
+          class="visual__link">
+          View graphic
+        </a>
+      </div>
+      <div class="visual__text">
+        <div class="rich-text" v-html="richBody"></div>
+      </div>
+    </div>
+
+    <CardActions label="Visual" :frag="'#' + cssId" />
+    <CardFooter />
+  </article>
+</template>
+
+<script>
+  import Global from '~/components/_Global';
+  import Card from '~/components/Card';
+  import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+
+  export default {
+    extends: Card,
+    mixins: [Global],
+
+    props: {
+      'content': Object,
+    },
+
+    data() {
+      return {
+        updatedAt: this.content.sys.updatedAt,
+      };
+    },
+
+    computed: {
+      cssId() {
+        return 'cf-' + this.content.sys.id;
+      },
+
+      secureImageUrl() {
+        return 'https:' + this.content.fields.image.fields.file.url;
+      },
+    },
+
+    created() {
+      this.richBody = this.content.fields.description ? documentToHtmlString(this.content.fields.description, this.renderOptions) : '';
+    },
+  }
+</script>
+
+<style lang="scss" scoped>
+  //
+  // Import shared variables
+  //
+  @import '~/assets/Global.scss';
+
+  .visual__image {
+    margin-bottom: 1rem;
+
+    .visual__img {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  .visual__text {
+    margin-bottom: 1rem;
+  }
+
+  .visual__title {
+    margin-bottom: 1em;
+    font-family: $roboto-condensed;
+    font-weight: 700;
+
+    [lang="ar"] & {
+      font-family: $kufi-bold;
+    }
+  }
+</style>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -66,6 +66,7 @@
           'clusterInformation': 'Cluster',
           'interactive': 'Interactive',
           'video': 'Video',
+          'visual': 'Visual',
         };
       },
     },

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'وسائل الإعلام',
   'Trends': 'الاتجاهات',
   'Visuals and Data': 'صور وبيانات',
+  'Visual': 'Visual',
   'Read more': 'إقراء المزيد',
   'Read less': 'إقراء أقل',
 

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -77,7 +77,6 @@ module.exports = {
   'Media': 'وسائل الإعلام',
   'Trends': 'الاتجاهات',
   'Visuals and Data': 'صور وبيانات',
-  'Visual': 'Visual',
   'Read more': 'إقراء المزيد',
   'Read less': 'إقراء أقل',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'تفاعلي',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'إقراء آخر تقاريرعن الوضع عن COUNTRY',

--- a/locales/en.js
+++ b/locales/en.js
@@ -76,8 +76,7 @@ module.exports = {
   'Forecast': 'Forecast',
   'Media': 'Media',
   'Trends': 'Trends',
-  'Visuals and Data': 'Visuals And Data',
-  'Visual': 'Visual',
+  'Visuals and Data': 'Visuals and Data',
   'Read more': 'Read more',
   'Read less': 'Read less',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'Interactive',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Read the latest from COUNTRY\'s Situation Report',

--- a/locales/en.js
+++ b/locales/en.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'Media',
   'Trends': 'Trends',
   'Visuals and Data': 'Visuals And Data',
+  'Visual': 'Visual',
   'Read more': 'Read more',
   'Read less': 'Read less',
 

--- a/locales/es.js
+++ b/locales/es.js
@@ -29,7 +29,7 @@ module.exports = {
   'Email': 'Correo electrónico',
   'Download': 'Descargar',
   'Archive': 'Archivo',
-  'Read this Situation Report in a different language:': 'Read this Situation Report in a different language:',
+  'Read this Situation Report in a different language:': 'Leer este informe de situación en otro idioma:',
 
   // AppFooter
   'Privacy policy': 'Política de confidencialidad',
@@ -96,8 +96,8 @@ module.exports = {
   'Read the latest from COUNTRY\'s Situation Report': 'Leer la última actualización del informe de situación de COUNTRY',
 
   // Card Actions
-  'Save Situation Report as PDF': 'Save Situation Report as PDF',
-  'Save THING as PNG': 'Save THING as PNG',
+  'Save Situation Report as PDF': 'Guardar el informe de situación como PDF',
+  'Save THING as PNG': 'Guardar THING como PNG',
 
   // Snap strings
   'Date of Creation': 'Fecha de creación',

--- a/locales/es.js
+++ b/locales/es.js
@@ -77,7 +77,6 @@ module.exports = {
   'Media': 'Medios',
   'Trends': 'Tendencias',
   'Visuals and Data': 'Visuales y datos',
-  'Visual': 'Visual',
   'Read more': 'Leer más',
   'Read less': 'Leer menos',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'Interactivo',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Leer la última actualización del informe de situación de COUNTRY',

--- a/locales/es.js
+++ b/locales/es.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'Medios',
   'Trends': 'Tendencias',
   'Visuals and Data': 'Visuales y datos',
+  'Visual': 'Visual',
   'Read more': 'Leer más',
   'Read less': 'Leer menos',
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'Médias',
   'Trends': 'Tendances',
   'Visuals and Data': 'Visuels et données',
+  'Visual': 'Visual',
   'Read more': 'Lire davantage',
   'Read less': 'Lire moins',
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -77,7 +77,6 @@ module.exports = {
   'Media': 'Médias',
   'Trends': 'Tendances',
   'Visuals and Data': 'Visuels et données',
-  'Visual': 'Visual',
   'Read more': 'Lire davantage',
   'Read less': 'Lire moins',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'Interactif',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'COUNTRY: lire la dernière mise à jour du rapport de situation',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -29,7 +29,7 @@ module.exports = {
   'Email': 'Email',
   'Download': 'Télécharger',
   'Archive': 'Archive',
-  'Read this Situation Report in a different language:': 'Read this Situation Report in a different language:',
+  'Read this Situation Report in a different language:': 'Lire ce rapport de situation dans une autre langue :',
 
   // AppFooter
   'Privacy policy': 'Privacy policy',
@@ -96,8 +96,8 @@ module.exports = {
   'Read the latest from COUNTRY\'s Situation Report': 'COUNTRY: lire la dernière mise à jour du rapport de situation',
 
   // Card Actions
-  'Save Situation Report as PDF': 'Save Situation Report as PDF',
-  'Save THING as PNG': 'Save THING as PNG',
+  'Save Situation Report as PDF': 'Sauvegarder le rapport de situation comme PDF',
+  'Save THING as PNG': 'Sauvegarder THING comme PNG',
 
   // Snap strings
   'Date of Creation': 'Date de création',

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'СМИ',
   'Trends': 'Тенденции',
   'Visuals and Data': 'Графические изображения и данные',
+  'Visual': 'Visual',
   'Read more': 'Читать далее',
   'Read less': 'Свернуть',
 

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -77,7 +77,6 @@ module.exports = {
   'Media': 'СМИ',
   'Trends': 'Тенденции',
   'Visuals and Data': 'Графические изображения и данные',
-  'Visual': 'Visual',
   'Read more': 'Читать далее',
   'Read less': 'Свернуть',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'Интерактивная версия',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Ознакомтесь с последними данными Оперативной сводки о COUNTRY',

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -77,6 +77,7 @@ module.exports = {
   'Media': 'Media',
   'Trends': 'Trends',
   'Visuals and Data': 'Visuals And Data',
+  'Visual': 'Visual',
   'Read more': 'Читати далі',
   'Read less': 'Згорнути',
 

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -77,7 +77,6 @@ module.exports = {
   'Media': 'Media',
   'Trends': 'Trends',
   'Visuals and Data': 'Visuals And Data',
-  'Visual': 'Visual',
   'Read more': 'Читати далі',
   'Read less': 'Згорнути',
 
@@ -89,6 +88,9 @@ module.exports = {
 
   // Interactives
   'Interactive': 'Interactive',
+
+  // Visuals
+  'Visual': 'Visual',
 
   // Social media
   'Read the latest from COUNTRY\'s Situation Report': 'Дізнайтесь про останні дані Оперативного зведення про COUNTRY',

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -45,6 +45,7 @@
   import KeyFinancials from '~/components/KeyFinancials';
   import KeyMessages from '~/components/KeyMessages';
   import Video from '~/components/Video';
+  import Visual from '~/components/Visual';
 
   import axios from 'axios';
   import {createClient} from '~/plugins/contentful.js';
@@ -67,6 +68,7 @@
       KeyFinancials,
       KeyMessages,
       Video,
+      Visual,
     },
 
     // Validate URL params


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-212

New content type which can be used to present full-width infographics and other dense imagery. Started as a clone of Interactive with some changes mainly on the Contentful side.

Can be inserted into the main content stream. As part of this work, the stream is now labeled "Content" instead of "Article" — bonus!

I also threw in some pending translations while I had the locales open.