### PR TITLE
DSR-166: logging

### DIFF
--- a/_stack/DSRWinstonReporter.js
+++ b/_stack/DSRWinstonReporter.js
@@ -1,0 +1,63 @@
+// @see https://github.com/nuxt/consola/blob/master/src/reporters/winston.js
+//
+// This reporter is compatible with Winston 3
+// https://github.com/winstonjs/winston
+
+// eslint-disable-next-line
+const _require = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require // bypass webpack
+
+export default class DSRWinstonReporter {
+  constructor (logger) {
+    if (logger && logger.log) {
+      this.logger = logger
+    } else {
+      const winston = _require('winston')
+
+      this.logger = winston.createLogger(Object.assign({
+        level: 'verbose',
+        format: winston.format.json(),
+        transports: [
+          //
+          // - Write all logs to `access.log`
+          //
+          new winston.transports.File({ filename: '/var/log/access.log' }),
+        ]
+      }, logger))
+    }
+  }
+
+  log (logObj) {
+    const data = [].concat(logObj.args)[0];
+
+    // Detect auth token
+    const authToken = data &&
+      data.config &&
+      data.config.headers &&
+      data.config.headers.Authorization &&
+      'Bearer *****';
+
+    // If we found a token, scrub it before logging
+    if (authToken) {
+      data.config.headers.Authorization = authToken;
+    }
+
+    // Send to logs
+    this.logger.log({
+      name: 'dsreports',
+      level: levels[logObj.level] || 'info',
+      label: logObj.tag,
+      msg: data.stack,
+      args: data,
+      timestamp: logObj.date,
+    })
+  }
+}
+
+const levels = {
+  0: 'error',
+  1: 'warn',
+  2: 'info',
+  3: 'verbose',
+  4: 'debug',
+  5: 'silly'
+}

--- a/_stack/DSRWinstonReporter.js
+++ b/_stack/DSRWinstonReporter.js
@@ -27,7 +27,7 @@ export default class DSRWinstonReporter {
   }
 
   log (logObj) {
-    const data = [].concat(logObj.args)[0];
+    const data = logObj.args[0];
 
     // Detect auth token
     const authToken = data &&
@@ -46,7 +46,7 @@ export default class DSRWinstonReporter {
       name: 'dsreports',
       level: levels[logObj.level] || 'info',
       label: logObj.tag,
-      msg: data.stack,
+      msg: data.message,
       args: data,
       timestamp: logObj.date,
     })

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,8 @@
 // Enable file-based logging
 import consola from 'consola';
-consola.setReporters(new consola.JSONReporter);
+import DSRWinstonReporter from './_stack/DSRWinstonReporter';
+
+consola.setReporters([new consola.FancyReporter, new DSRWinstonReporter]);
 consola.wrapConsole();
 
 // Contentful + Environment variables

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,9 @@
-// Contentful + Environment variables
+// Enable file-based logging
+import consola from 'consola';
+consola.setReporters(new consola.JSONReporter);
+consola.wrapConsole();
 
+// Contentful + Environment variables
 // These allow us to query Contentful and get all of our valid URLs.
 const contentful = require('contentful');
 const client = contentful.createClient({
@@ -17,7 +21,7 @@ module.exports = {
     CTF_HOST: process.env.CTF_HOST || 'cdn.contentful.com',
     CTF_SPACE_ID: process.env.CTF_SPACE_ID || '123456',
     CTF_ENVIRONMENT: process.env.CTF_ENVIRONMENT || 'master',
-    CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN || '1234567890', 
+    CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN || '1234567890',
     CTF_CDA_PREVIEW_TOKEN: process.env.CTF_CDA_PREVIEW_TOKEN,
     baseUrl: process.env.BASE_URL || 'http://dev.dsr.local',
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "vue": "^2.0.0",
     "vue-clickaway": "^2.2.2",
     "vue-i18n": "^8.3.2",
-    "webpack": "^4.20.2"
+    "webpack": "^4.20.2",
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@nuxtjs/moment": "^1.0.0",
     "ajv": "^6.5.4",
     "axios": "^0.18.0",
+    "consola": "^2.6.0",
     "contentful": "^7.1.0",
     "file-saver": "^2.0.0",
     "lodash": ">=4.17.11",

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -272,6 +272,10 @@
         'flashUpdatesAll': flashUpdates.items,
       };
     }).catch((err) => {
+      // Log to our stack
+      console.error(err);
+
+      // Display Nuxt error page
       error({ statusCode: 404, message: err.message });
     });
   }

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -239,9 +239,13 @@
 
     ]).then(([entries, translationEntries, flashUpdates, ftsData2018, ftsData2019]) => {
 
-      // If contentful doesn't return an entry, display error
+      // If Contentful doesn't return an Entry, log error
       if (entries.items.length === 0) {
-        throw new Error('No entry in contentful with that slug');
+        throw ({args:[{
+          message: 'No entry found in Contentful with requested language/slug',
+          lang: params.lang,
+          slug: params.slug,
+        }]});
       }
 
       // For client-side, update our store with the fresh data.

--- a/pages/_lang/index.vue
+++ b/pages/_lang/index.vue
@@ -114,6 +114,7 @@
           'sitreps': sitreps.items,
         }
       }).catch((err) => {
+        console.error(err);
         error({ statusCode: 404, message: err.message });
       });
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8579,8 +8579,8 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz#2756f46cb3258054c5f4723de8ae7e87302a1ccf"
 
 vue-i18n@^8.3.2:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.10.0.tgz#e95f215b5548bedf5610c14506acb3438717b6bd"
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.11.1.tgz#1a17792d6d2d7abf41444c256f232507a91cbd30"
 
 vue-loader@^15.7.0:
   version "15.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2265,12 +2265,34 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
 color@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.1.tgz#7abf5c0d38e89378284e873c207ae2172dcc8a61"
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+colornames@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
+
+colors@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+
+colorspace@1.1.x:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.1.tgz#9ac2491e1bc6f8fb690e2176814f8d091636d972"
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
@@ -2913,6 +2935,14 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+diagnostics@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.1.tgz#cab6ac33df70c9d9a727490ae43ac995a769b22a"
+  dependencies:
+    colorspace "1.1.x"
+    enabled "1.0.x"
+    kuler "1.0.x"
+
 didyoumean2@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/didyoumean2/-/didyoumean2-1.3.0.tgz#6e34f40143351c920696e9723bba01ffc0b96402"
@@ -3047,6 +3077,12 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+enabled@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
+  dependencies:
+    env-variable "0.0.x"
+
 encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -3077,6 +3113,10 @@ enhanced-resolve@^4.1.0:
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+
+env-variable@0.0.x:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.5.tgz#913dd830bef11e96a039c038d4130604eba37f88"
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3485,6 +3525,10 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
+
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
@@ -3496,6 +3540,10 @@ fd-slicer@~1.0.1:
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   dependencies:
     pend "~1.2.0"
+
+fecha@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -5122,6 +5170,12 @@ kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
 
+kuler@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-1.0.1.tgz#ef7c784f36c9fb6e16dd3150d152677b2b0228a6"
+  dependencies:
+    colornames "^1.1.1"
+
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
@@ -5371,6 +5425,16 @@ log-update@^1.0.2:
   dependencies:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
+
+logform@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.1.2.tgz#957155ebeb67a13164069825ce67ddb5bb2dd360"
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^2.3.3"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.0.0, loose-envify@^1.2.0:
   version "1.4.0"
@@ -6024,6 +6088,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+one-time@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
 
 onetime@^1.0.0:
   version "1.1.0"
@@ -7876,7 +7944,7 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
 
-stack-trace@0.0.10:
+stack-trace@0.0.10, stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
@@ -8189,6 +8257,10 @@ test-exclude@^5.2.2:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -8317,6 +8389,10 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
 
 "true-case-path@^1.0.2":
   version "1.0.3"
@@ -8837,6 +8913,27 @@ widest-line@^2.0.0:
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
   dependencies:
     string-width "^2.1.1"
+
+winston-transport@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.3.0.tgz#df68c0c202482c448d9b47313c07304c2d7c2c66"
+  dependencies:
+    readable-stream "^2.3.6"
+    triple-beam "^1.2.0"
+
+winston@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.2.1.tgz#63061377976c73584028be2490a1846055f77f07"
+  dependencies:
+    async "^2.6.1"
+    diagnostics "^1.1.1"
+    is-stream "^1.1.0"
+    logform "^2.1.1"
+    one-time "0.0.4"
+    readable-stream "^3.1.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.3.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-166

Logs all info to `/var/log/access.log` — currently set to `VERBOSE`, so it will include stuff like webpack info.

I sanitized the tokens that I found in one type of error. There might be more but our API keys are not shared across environments, so we can deploy to dev and see what happens without endangering our prod API token.