### PR TITLE
DSR-218: fix typo in props for Interactive>CardActions

### DIFF
--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -62,7 +62,7 @@
       </div>
     </div>
 
-    <CardActions label="interactive" :frag="'#' + cssId" />
+    <CardActions label="Interactive" :frag="'#' + cssId" />
     <CardFooter />
   </article>
 </template>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-218

Caught while locally testing #211 

```
11:06:51  WARN  [vue-i18n] Value of key 'interactive' is not a string!
11:06:51  WARN  [vue-i18n] Cannot translate the value of keypath 'interactive'. Use the value of keypath as default.
```