### PR TITLE
DSR-233: Arabic display issues

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -7,7 +7,6 @@
       <div class="title-area__headings">
         <h1
           class="title title--sitrep"
-          :class="{'title--is-multilingual': titleIsMultilingual}"
         >{{ title }}</h1>
 
         <span class="subtitle" v-if="subtitle">{{ subtitle }}</span>
@@ -75,7 +74,6 @@
     },
 
     props: {
-      'titleIsMultilingual': Boolean,
       'title': String,
       'subtitle': String,
       'updated': String,
@@ -308,15 +306,8 @@
     font-weight: 700;
     text-transform: uppercase;
     margin-top: 0 - $header-padding;
-  }
 
-  // SitReps are EN only for now, but other page titles can be in any language.
-  // we set up a special prop that can be set when implementing the AppHeader on
-  // a page.
-  .title--is-multilingual {
-    font-family: $roboto-condensed;
-    font-size: 2em;
-
+    // Allow Arabic-language titles in the official font.
     [lang="ar"] & {
       margin-bottom: .333em;
       font-family: $kufi-bold;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -372,7 +372,12 @@ main code {
 
 //—— Rich Text —————————————————————————————————————————————————————————————————
 
-.rich-text {}
+.rich-text {
+  // DSR-233: right edge of text was getting cut off in Chrome using Dubai font.
+  [lang="ar"] & {
+    padding-right: 2px;
+  }
+}
 .rich-text * {
   margin-bottom: 1em;
 }


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-233

Fixing two issues:

- SitRep title (the country name) was displaying in wrong font in Arabic
- Right edge of rich-text fields were getting chopped off in at least macOS Chrome (maybe elsewhere TBD pending feedback from folks offering QA)