### PR TITLE
DSR-230: specify English About page on root URL

### DIFF
--- a/pages/_lang/index.vue
+++ b/pages/_lang/index.vue
@@ -110,6 +110,8 @@
     },
 
     asyncData({env, params, store, error}) {
+      const currentLang = (params && typeof params.lang !== 'undefined') ? params.lang : 'en';
+
       return Promise.all([
         // Fetch all SitReps without populating any Links (references, images, etc).
         client.getEntries({
@@ -121,8 +123,8 @@
         client.getEntries({
           'include': 0,
           'content_type': 'page',
-          'fields.slug': params.slug,
-          'fields.language': params.lang,
+          'fields.slug': 'about', // slug is hard-coded here
+          'fields.language': currentLang,
         })
       ]).then(([sitreps, about]) => {
         let bodyRichText = about && about.items[0] && about.items[0].fields && about.items[0].fields.body ? about.items[0].fields.body : false;


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-230

I'd forgotten to hardcode the language param when loading the root URL, which lacks the params present on the other language-specific URLs. Additionally, the slug needs to be hardcoded or we'll pull up any old piece of content if new pages are ever added.