### PR TITLE
DSR-241: re-enable manual Funding field

### DIFF
--- a/_migrations/16-update-keyFinancialsManual.js
+++ b/_migrations/16-update-keyFinancialsManual.js
@@ -1,0 +1,25 @@
+module.exports = function(migration) {
+  //
+  // ContentType: keyFinancialsManual
+  //
+  const keyFinancialsManual = migration.editContentType('keyFinancialsManual')
+
+  keyFinancialsManual
+    .name('Funding (manually entered)')
+    .description('Manually-entered Key Financial data. Used as fallback when FTS URL cannot be found.')
+
+  keyFinancialsManual.editField('financial')
+    .name('Funding figure')
+
+  //
+  // Field: SitRep uses keyFinancialsManual (1-to-many)
+  //
+  const sitrep = migration.editContentType('sitrep')
+
+  sitrep.editField('keyFinancialsManual')
+    .name('Funding (manually entered)')
+    .disabled(false)
+
+  sitrep.editField('keyFinancialsUrl')
+    .required(false)
+};

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -41,14 +41,14 @@
     mixins: [Global],
 
     props: {
-      'content': Array,
+      'ftsRawData': Array,
       'ftsUrl': String,
     },
 
     computed: {
       cssId() {
-        if (typeof this.content === 'Array' && this.content.length > 0) {
-          return 'cf-' + this.content.map((item) => item.sys.id).join('_');
+        if (typeof this.ftsRawData === 'Array' && this.ftsRawData.length > 0) {
+          return 'cf-' + this.ftsRawData.map((item) => item.sys.id).join('_');
         }
         else {
           return 'cf-keyFinancials-notAvailable';
@@ -60,7 +60,7 @@
       },
 
       ftsData() {
-        const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
+        const plan = this.ftsRawData && this.ftsRawData.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
         // If we failed to fetch FTS Data along the way, return nothing and our
         // template will display a prepared error message.
@@ -109,7 +109,7 @@
       },
 
       ftsDataYear() {
-        const plan = this.content && this.content.filter(plan => plan.id === this.ftsPlanId)[0] || false;
+        const plan = this.ftsRawData && this.ftsRawData.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
         return plan && this.$moment.utc(plan.startDate).locale(this.locale).format('YYYY');
       },

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -25,7 +25,7 @@
         <br><br>
       </div>
     </div>
-    <a :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
+    <a v-if="!!ftsUrl" :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
 
     <CardActions label="Funding" :frag="'#' + cssId" />
     <CardFooter />
@@ -41,17 +41,33 @@
     mixins: [Global],
 
     props: {
-      'ftsRawData': Array,
-      'ftsUrl': String,
+      'ftsRawData': {
+        required: false,
+        type: Array,
+        default: () => [],
+      },
+      'ftsUrl': {
+        required: false,
+        type: String,
+        default: '',
+      },
+      'ftsManualData': {
+        required: false,
+        type: Array,
+        default: () => [],
+      }
     },
 
     computed: {
       cssId() {
-        if (typeof this.ftsRawData === 'Array' && this.ftsRawData.length > 0) {
-          return 'cf-' + this.ftsRawData.map((item) => item.sys.id).join('_');
+        if (this.ftsPlanId) {
+          return 'cf-keyFinancials-fts-' + this.ftsPlanId;
+        }
+        else if (typeof this.ftsData !== 'undefined' && this.ftsData.length > 0) {
+          return 'cf-' + this.ftsData.map((item) => item.sys.id).join('_');
         }
         else {
-          return 'cf-keyFinancials-notAvailable';
+          return 'cf-keyFinancials';
         }
       },
 
@@ -62,50 +78,56 @@
       ftsData() {
         const plan = this.ftsRawData && this.ftsRawData.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
-        // If we failed to fetch FTS Data along the way, return nothing and our
-        // template will display a prepared error message.
-        if (!plan) {
+        if (plan) {
+          // The structure mimics Contentful JSON API with some extra data so that
+          // our template above doesn't have to be duplicated based on input data.
+          return [
+            {
+              sys: {
+                id: `${this.ftsPlanId}-requirements.revisedRequirements`,
+              },
+              fields: {
+                type: 'requirements',
+                raw: plan.requirements.revisedRequirements,
+                financial: '$' + this.formatNumber(plan.requirements.revisedRequirements),
+                caption: this.$t('Requirements', this.locale),
+              },
+            },
+            {
+              sys: {
+                id: `${this.ftsPlanId}-funding.totalFunding`,
+              },
+              fields: {
+                type: 'total',
+                raw: plan.funding.totalFunding,
+                financial: '$' + this.formatNumber(plan.funding.totalFunding),
+                caption: this.$t('Funding', this.locale),
+              },
+            },
+            {
+              sys: {
+                id: `${this.ftsPlanId}-funding.progress`,
+              },
+              fields: {
+                type: 'progress',
+                // Do not allow raw vals greater than 100. Pie chart will break.
+                raw: (plan.funding.progress > 100) ? 100 : plan.funding.progress,
+                financial: Math.round(plan.funding.progress) + '%',
+                caption: this.$t('Progress', this.locale),
+              },
+            },
+          ];
+        }
+        // If FTS URL is missing, check for manually-entered data to render.
+        else if (!plan && typeof this.ftsManualData !== 'undefined' && this.ftsManualData.length > 0) {
+          return this.ftsManualData;
+        }
+        // If we failed to fetch FTS Data along the way, and no manual data was
+        // supplied, then return nothing and our template will display a prepared
+        // error message.
+        else {
           return [];
         }
-
-        // The structure mimics Contentful JSON API so that our template above
-        // doesn't have to be duplicated based on input data.
-        return [
-          {
-            sys: {
-              id: `${this.ftsPlanId}-requirements.revisedRequirements`,
-            },
-            fields: {
-              type: 'requirements',
-              raw: plan.requirements.revisedRequirements,
-              financial: '$' + this.formatNumber(plan.requirements.revisedRequirements),
-              caption: this.$t('Requirements', this.locale),
-            },
-          },
-          {
-            sys: {
-              id: `${this.ftsPlanId}-funding.totalFunding`,
-            },
-            fields: {
-              type: 'total',
-              raw: plan.funding.totalFunding,
-              financial: '$' + this.formatNumber(plan.funding.totalFunding),
-              caption: this.$t('Funding', this.locale),
-            },
-          },
-          {
-            sys: {
-              id: `${this.ftsPlanId}-funding.progress`,
-            },
-            fields: {
-              type: 'progress',
-              // Do not allow raw vals greater than 100. Pie chart will break.
-              raw: (plan.funding.progress > 100) ? 100 : plan.funding.progress,
-              financial: Math.round(plan.funding.progress) + '%',
-              caption: this.$t('Progress', this.locale),
-            },
-          },
-        ];
       },
 
       ftsDataYear() {

--- a/components/README.md
+++ b/components/README.md
@@ -6,6 +6,7 @@ Generally, each file in this directory corresponds to one unique component. In s
 * `Snap.vue` is a shared component with specific implementations `SnapCard.vue` and `SnapPage.vue` — they have common functionality but each variant has unique properties or behaviors.
 * `Card.vue` is an _extendable_ component. It doesn't do much on its own but again provide common functionality to other components which consider themselves cards. It includes the common subcomponents and contains a few methods and styles common to all cards.
 * `KeyMessages` got renamed to **Highlights** on the surface, but all the underlying code in both Contentful and Vue is `KeyMessages`
+* `KeyFinancials` got renamed to **Funding** on the surface, but all the underlying code in both Contentful and Vue is `KeyFinancials`
 
 ## Authoring RTL CSS
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -18,7 +18,7 @@
       <section class="section--primary clearfix">
         <KeyMessages :messages="entry.fields.keyMessages" :image="entry.fields.keyMessagesImage" />
         <KeyFigures :content="entry.fields.keyFigure" />
-        <KeyFinancials :fts-raw-data="ftsData" :fts-url="entry.fields.keyFinancialsUrl" />
+        <KeyFinancials :fts-raw-data="ftsData" :fts-manual-data="entry.fields.keyFinancialsManual" :fts-url="entry.fields.keyFinancialsUrl" />
         <Contacts :content="entry.fields.contacts" />
       </section>
 

--- a/pages/_lang/country/_slug.vue
+++ b/pages/_lang/country/_slug.vue
@@ -18,7 +18,7 @@
       <section class="section--primary clearfix">
         <KeyMessages :messages="entry.fields.keyMessages" :image="entry.fields.keyMessagesImage" />
         <KeyFigures :content="entry.fields.keyFigure" />
-        <KeyFinancials :content="ftsData" :ftsUrl="entry.fields.keyFinancialsUrl" />
+        <KeyFinancials :fts-raw-data="ftsData" :fts-url="entry.fields.keyFinancialsUrl" />
         <Contacts :content="entry.fields.contacts" />
       </section>
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-241

We have an office onboarding that lacks an FTS entry. This PR re-enables the manual Funding field and stops requiring FTS URL to be populated. The component now attempts these three scenarios (in this order):

1. **Valid FTS data was supplied**. We show Funding stats, an HRP year, the FTS link, and the progress pie chart.
2. **No FTS URL supplied, but manual figures were entered.** We show the figures, but no HRP year, no link to FTS, nor do we render the pie chart.
3. **No valid FTS URL was entered, and no manual figures were provided.** We show the branded error message.

### Valid FTS URL
<img width="367" alt="DSR-241-1-fts-data" src="https://user-images.githubusercontent.com/254753/59258175-b9372680-8c37-11e9-9153-2fe057188548.png">

### Manual Funding figures
<img width="366" alt="DSR-241-2-manual-data" src="https://user-images.githubusercontent.com/254753/59258177-b9cfbd00-8c37-11e9-8b06-4db20d5096b5.png">

### No valid data available
<img width="365" alt="DSR-241-3-no-data" src="https://user-images.githubusercontent.com/254753/59258178-b9cfbd00-8c37-11e9-91c0-72fa71b73690.png">
