### PR TITLE
DSR-241: only display FTS link when valid data was found

### DIFF
--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -25,7 +25,7 @@
         <br><br>
       </div>
     </div>
-    <a v-if="!!ftsUrl" :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
+    <a v-if="ftsDataYear" :href="ftsUrl" target="_blank" class="fts-url">FTS</a>
 
     <CardActions label="Funding" :frag="'#' + cssId" />
     <CardFooter />


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-241

Follow-up to #240 

If the URL is present, but points to a non-existent plan, we should suppress the link. By checking for the Year within the plan, we are certain that valid FTS data was found.