### PR TITLE
DSR-247: guard against unrendered FlashUpdate article text

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -127,13 +127,21 @@
         let article = this.$refs['article'];
         let articleImg = this.$refs['articleImg'];
 
-        // Set the article's min-height to the height of the image
+        // Set the article's min-height to the constant, or if the image is
+        // present, the height of the image.
         this.articleMinHeight = (!!this.articleHasImage) ? Math.max(articleImg.clientHeight, this.articleMinHeight) : this.articleMinHeight;
 
+        // First-check if the article $ref is there at all. Since FlashUpdate
+        // extends Article, it is possible for this calculation to run when the
+        // DOM does NOT contain a corresponding element for our $refs['article']
+        //
         // If the truncated article text will be sufficiently longer than the
         // accompanying image or the minimum defined in data(), then we apply
         // the 'Read More' treatment.
-        if (article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)) {
+        if (
+          typeof article !== 'undefined'
+          && article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)
+        ) {
           this.articleHeight = article.clientHeight;
           this.isExpandable = true;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-247

Since FlashUpdate extends Article now, the height calculations are still run even when no FlashUpdate is present. Some additional logic is added in order to avoid running the DOM calculation unless the element is found.