### PR TITLE
DSR-251: more robust youtube url parsing

### DIFF
--- a/components/Video.vue
+++ b/components/Video.vue
@@ -111,7 +111,7 @@
         }
 
         return decodeURIComponent(results[2].replace(/\+/g, ' '));
-      }
+      },
     },
 
     created() {

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -69,7 +69,8 @@
         return 'cf-' + this.content.sys.id;
       },
       videoSlug() {
-        return this.content.fields.videoUrl.split('=')[1];
+        const videoSlug = this.parseQueryParams('v');
+        return videoSlug;
       },
       videoEmbedLink() {
         return 'https://www.youtube.com/watch?v=' + this.videoSlug;
@@ -89,6 +90,28 @@
 
         this.videoProcessed = true;
       },
+
+      // Parse URL parameters
+      //
+      // Since IE11+node don't support URLSearchParams
+      //
+      // @see https://stackoverflow.com/a/901144
+      // @see https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility
+      parseQueryParams(name) {
+        name = name.replace(/[\[\]]/g, '\\$&');
+        const url = this.content.fields.videoUrl;
+        const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
+        const results = regex.exec(url);
+
+        if (!results) {
+          return null;
+        }
+        if (!results[2]) {
+          return '';
+        }
+
+        return decodeURIComponent(results[2].replace(/\+/g, ' '));
+      }
     },
 
     created() {

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -331,7 +331,7 @@
             headers: req && req.headers,
             ip: req && req.ip || req.headers['x-forwarded-for'] || req.socket.remoteAddress || req.connection.remoteAddress,
             // Since no exception is being thrown, res.statusCode = 200 so we have
-            // to set 404 manually on account of the dataset being empty.
+            // to set 500 manually on account of the problems we detected.
             response: res && 500,
           }],
         });


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-251

I had really naive URL parsing for our video embeds. The contentful validation was enough to ensure we always get a real URL, but I never accounted for extra params that might exist at the end. This should fix it, and allow us to ignore all params except the video slug.