### PR TITLE
DSR-247: only run computeArticleHeight when we find an Article DOM node

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -127,21 +127,21 @@
         let article = this.$refs['article'];
         let articleImg = this.$refs['articleImg'];
 
+        // First, check if the article $ref is there at all. Since FlashUpdate
+        // extends Article, it is possible for this calculation to run when the
+        // DOM does NOT contain a corresponding element for $refs['article']
+        if (typeof article === 'undefined') {
+          return;
+        }
+
         // Set the article's min-height to the constant, or if the image is
-        // present, the height of the image.
+        // present, the height of the image + caption.
         this.articleMinHeight = (!!this.articleHasImage) ? Math.max(articleImg.clientHeight, this.articleMinHeight) : this.articleMinHeight;
 
-        // First-check if the article $ref is there at all. Since FlashUpdate
-        // extends Article, it is possible for this calculation to run when the
-        // DOM does NOT contain a corresponding element for our $refs['article']
-        //
-        // If the truncated article text will be sufficiently longer than the
+        // If the expanded article text will be sufficiently longer than the
         // accompanying image or the minimum defined in data(), then we apply
         // the 'Read More' treatment.
-        if (
-          typeof article !== 'undefined'
-          && article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)
-        ) {
+        if (article.clientHeight > (this.articleMinHeight + this.articleMinGrowth)) {
           this.articleHeight = article.clientHeight;
           this.isExpandable = true;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-247

This is a followup to 194e8ba.

The original logic was not strict enough, and an expired Flash Update was still creating JS errors because I'd only guarded one conditional from missing FUs, and both of them tried to access the `clientHeight` of one of the DOM `$refs`.

New function just checks up front for `this.$refs['article']` and stops execution completely when it's found to be `undefined` — the defaults for the component then take over and all is peachy.