### PR TITLE
DSR-203: lazy-load images using HTML attribute

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -22,7 +22,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
             <source type="image/jpeg"
@@ -34,7 +34,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
             <img

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -39,6 +39,8 @@
 
             <img
               class="article__img"
+              loading="lazy"
+              lazyload="1"
               :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -43,6 +43,8 @@
 
             <img
               class="article__img"
+              loading="lazy"
+              lazyload="1"
               :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -26,7 +26,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
             <source type="image/jpeg"
@@ -38,7 +38,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4)\
+                (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
             <img

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -45,6 +45,8 @@
 
             <img
               class="interactive__img"
+              loading="lazy"
+              lazyload="1"
               :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
               :alt="content.fields.image.fields.title">
           </picture>

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -24,7 +24,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 800px) calc((100vw - 10rem) / 2)\
+                (min-width: 800px) calc((100vw - 10rem) / 2),\
                 (min-width: 1220px) 515px" />
 
             <source type="image/jpeg"
@@ -36,7 +36,7 @@
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 800px) calc((100vw - 10rem) / 2)\
+                (min-width: 800px) calc((100vw - 10rem) / 2),\
                 (min-width: 1220px) 515px" />
 
             <img

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -39,7 +39,10 @@
                 (min-width: 800px) calc((100vw - 10rem) / 2)\
                 (min-width: 1220px) 515px" />
 
-            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'" :alt="image.fields.title" loading="auto">
+            <img
+              :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'"
+              :alt="image.fields.title"
+              loading="auto">
           </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
         </figure>

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -39,7 +39,7 @@
                 (min-width: 800px) calc((100vw - 10rem) / 2)\
                 (min-width: 1220px) 515px" />
 
-            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'" :alt="image.fields.title">
+            <img :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'" :alt="image.fields.title" loading="auto">
           </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
         </figure>

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -26,7 +26,7 @@
           target="_blank"
           rel="noopener"
           class="video__container">
-          <img class="video__img" :src="videoEmbedPreview">
+          <img class="video__img" loading="lazy" lazyload="1" :src="videoEmbedPreview">
           <button class="video__play"></button>
         </a>
       </div>

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -26,7 +26,12 @@
           target="_blank"
           rel="noopener"
           class="video__container">
-          <img class="video__img" loading="lazy" lazyload="1" :src="videoEmbedPreview">
+          <img
+            class="video__img"
+            loading="lazy"
+            lazyload="1"
+            :src="videoEmbedPreview"
+            :alt="`Preview of ${videoEmbedLink}`">
           <button class="video__play"></button>
         </a>
       </div>

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -36,6 +36,8 @@
 
           <img
             class="visual__img"
+            loading="lazy"
+            lazyload="1"
             :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
             :alt="content.fields.image.fields.title">
         </picture>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-203

This is about as great as it gets in the web-perf world! I added two HTML attributes to all of our images within the main content area of a SitRep: Article, FlashUpdate, Interactive, Visuals, Videos.

These tiny HTML attributes direct browsers to defer the loading of images until needed. Lazy-loading with zero JS or other weird trickery!

Currently IE11 and Chrome 76+ support the attributes (I added an older, but stable attribute for IE11). Firefox, Safari, Edge et. al will have support coming.

While testing I also discovered a missing comma in the `<picture>` markup, which should improve image selection logic for devices within the affected media queries.