### PR TITLE
DSR-265: display original format in picture tags

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -25,12 +25,12 @@
                 (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
-            <source type="image/jpeg"
+            <source
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=jpg 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=jpg 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + ' 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + ' 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + ' 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -41,7 +41,7 @@
               class="article__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image)"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -14,34 +14,40 @@
         <figure ref="articleImg">
           <picture>
             <source type="image/webp"
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=webp 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=webp 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=webp 1239w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4),\
-                (min-width: 1220px) 413px" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)}&fm=webp 320w,
+                ${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}&fm=webp 413w,
+                ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)}&fm=webp 826w,
+                ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)}&fm=webp 1239w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 900px) calc((1080px - 2rem) * .4),
+                (min-width: 1220px) 413px
+              `"
+            />
 
             <source
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + ' 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + ' 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + ' 1239w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4),\
-                (min-width: 1220px) 413px" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)} 320w,
+                ${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)} 413w,
+                ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)} 826w,
+                ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)} 1239w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 900px) calc((1080px - 2rem) * .4),
+                (min-width: 1220px) 413px
+              `"
+            />
 
             <img
               class="article__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image)"
+              :src="`${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}`"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -29,12 +29,12 @@
                 (min-width: 900px) calc((1080px - 2rem) * .4),\
                 (min-width: 1220px) 413px" />
 
-            <source type="image/jpeg"
+            <source
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=jpg 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=jpg 1239w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
+                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + ' 413w,\
+                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + ' 826w,\
+                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + ' 1239w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -45,7 +45,7 @@
               class="article__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image)"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -18,34 +18,40 @@
         <figure ref="articleImg">
           <picture>
             <source type="image/webp"
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + '&fm=webp 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + '&fm=webp 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + '&fm=webp 1239w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4),\
-                (min-width: 1220px) 413px" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)}&fm=webp 320w,
+                ${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}&fm=webp 413w,
+                ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)}&fm=webp 826w,
+                ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)}&fm=webp 1239w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 900px) calc((1080px - 2rem) * .4),
+                (min-width: 1220px) 413px
+              `"
+            />
 
             <source
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
-                '+ secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image) + ' 413w,\
-                '+ secureImageUrl + '?w=826&h=' + getImageHeight(826, content.fields.image) + ' 826w,\
-                '+ secureImageUrl + '?w=1239&h=' + getImageHeight(1239, content.fields.image) + ' 1239w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 900px) calc((1080px - 2rem) * .4),\
-                (min-width: 1220px) 413px" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)} 320w,
+                ${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)} 413w,
+                ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)} 826w,
+                ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)} 1239w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 900px) calc((1080px - 2rem) * .4),
+                (min-width: 1220px) 413px
+              `"
+            />
 
             <img
               class="article__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=413&h=' + getImageHeight(413, content.fields.image)"
+              :src="`${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}`"
               :alt="content.fields.image.fields.title">
           </picture>
           <figcaption v-if="content.fields.image.fields.description">

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -31,13 +31,13 @@
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
                 (min-width: 1220px) calc(1080px - 2rem)" />
 
-            <source type="image/jpeg"
+            <source
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=jpg 640w,\
-                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=jpg 960w,\
-                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=jpg 1280w,\
-                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=jpg 1920w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + ' 640w,\
+                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + ' 960w,\
+                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + ' 1280w,\
+                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + ' 1920w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -47,7 +47,7 @@
               class="interactive__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image)"
               :alt="content.fields.image.fields.title">
           </picture>
         </a>

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -20,34 +20,40 @@
           class="interactive__link">
           <picture>
             <source type="image/webp"
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=webp 640w,\
-                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=webp 960w,\
-                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=webp 1280w,\
-                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=webp 1920w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 1220px) calc(1080px - 2rem)" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)}&fm=webp 320w,
+                ${secureImageUrl}?w=640&h=${getImageHeight(640, content.fields.image)}&fm=webp 640w,
+                ${secureImageUrl}?w=960&h=${getImageHeight(960, content.fields.image)}&fm=webp 960w,
+                ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)}&fm=webp 1280w,
+                ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)}&fm=webp 1920w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 1220px) calc(1080px - 2rem)
+              `"
+            />
 
             <source
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + ' 640w,\
-                '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + ' 960w,\
-                '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + ' 1280w,\
-                '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + ' 1920w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 1220px) calc(1080px - 2rem)" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)} 320w,
+                ${secureImageUrl}?w=640&h=${getImageHeight(640, content.fields.image)} 640w,
+                ${secureImageUrl}?w=960&h=${getImageHeight(960, content.fields.image)} 960w,
+                ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)} 1280w,
+                ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)} 1920w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 1220px) calc(1080px - 2rem)
+              `"
+            />
 
             <img
               class="interactive__img"
               loading="lazy"
               lazyload="1"
-              :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image)"
+              :src="`${secureImageUrl}?w=1048&h=${getImageHeight(1048, content.fields.image)}`"
               :alt="content.fields.image.fields.title">
           </picture>
         </a>

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -27,12 +27,12 @@
                 (min-width: 800px) calc((100vw - 10rem) / 2),\
                 (min-width: 1220px) 515px" />
 
-            <source type="image/jpeg"
+            <source
               :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + '&fm=jpg 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + '&fm=jpg 640w,\
-                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + '&fm=jpg 800w,\
-                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg 1032w'"
+                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + ' 320w,\
+                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + ' 640w,\
+                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + ' 800w,\
+                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + ' 1032w'"
               sizes="\
                 calc(100vw - 4rem),\
                 (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -40,7 +40,7 @@
                 (min-width: 1220px) 515px" />
 
             <img
-              :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=jpg'"
+              :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image)"
               :alt="image.fields.title"
               loading="auto">
           </picture>

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -16,33 +16,39 @@
         <figure>
           <picture class="image">
             <source type="image/webp"
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + '&fm=webp 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + '&fm=webp 640w,\
-                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + '&fm=webp 800w,\
-                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + '&fm=webp 1032w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 800px) calc((100vw - 10rem) / 2),\
-                (min-width: 1220px) 515px" />
-
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, image)}&fm=webp 320w,
+                ${secureImageUrl}?w=640&h=${getImageHeight(640, image)}&fm=webp 640w,
+                ${secureImageUrl}?w=800&h=${getImageHeight(800, image)}&fm=webp 800w,
+                ${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)}&fm=webp 1032w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 800px) calc((100vw - 10rem) / 2),
+                (min-width: 1220px) 515px
+              `"
+            />
             <source
-              :srcset="'\
-                '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, image) + ' 320w,\
-                '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, image) + ' 640w,\
-                '+ secureImageUrl + '?w=800&h=' + getImageHeight(800, image) + ' 800w,\
-                '+ secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image) + ' 1032w'"
-              sizes="\
-                calc(100vw - 4rem),\
-                (min-width: 600px) calc(100vw - 8rem - 2rem),\
-                (min-width: 800px) calc((100vw - 10rem) / 2),\
-                (min-width: 1220px) 515px" />
+              :srcset="`
+                ${secureImageUrl}?w=320&h=${getImageHeight(320, image)} 320w,
+                ${secureImageUrl}?w=640&h=${getImageHeight(640, image)} 640w,
+                ${secureImageUrl}?w=800&h=${getImageHeight(800, image)} 800w,
+                ${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)} 1032w
+              `"
+              sizes="`
+                calc(100vw - 4rem),
+                (min-width: 600px) calc(100vw - 8rem - 2rem),
+                (min-width: 800px) calc((100vw - 10rem) / 2),
+                (min-width: 1220px) 515px
+              `"
+            />
 
             <img
-              :src="secureImageUrl + '?w=1032&h=' + getImageHeight(1032, image)"
+              :src="`${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)}`"
               :alt="image.fields.title"
-              loading="auto">
+              loading="auto"
+            >
           </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>
         </figure>

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -11,34 +11,39 @@
       <div class="visual__image" v-if="content.fields.image">
         <picture>
           <source type="image/webp"
-            :srcset="'\
-              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=webp 320w,\
-              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=webp 640w,\
-              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=webp 960w,\
-              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=webp 1280w,\
-              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=webp 1920w'"
-            sizes="\
-              calc(100vw - 4rem),\
-              (min-width: 600px) calc(100vw - 8rem - 2rem),\
-              (min-width: 1220px) calc(1080px - 2rem)" />
-
+            :srcset="`
+              ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)}&fm=webp 320w,
+              ${secureImageUrl}?w=640&h=${getImageHeight(640, content.fields.image)}&fm=webp 640w,
+              ${secureImageUrl}?w=960&h=${getImageHeight(960, content.fields.image)}&fm=webp 960w,
+              ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)}&fm=webp 1280w,
+              ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)}&fm=webp 1920w
+            `"
+            sizes="`
+              calc(100vw - 4rem),
+              (min-width: 600px) calc(100vw - 8rem - 2rem),
+              (min-width: 1220px) calc(1080px - 2rem)
+            `"
+          />
           <source
-            :srcset="'\
-              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
-              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + ' 640w,\
-              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + ' 960w,\
-              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + ' 1280w,\
-              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + ' 1920w'"
-            sizes="\
-              calc(100vw - 4rem),\
-              (min-width: 600px) calc(100vw - 8rem - 2rem),\
-              (min-width: 1220px) calc(1080px - 2rem)" />
+            :srcset="`
+              ${secureImageUrl}?w=320&h=${getImageHeight(320, content.fields.image)} 320w,
+              ${secureImageUrl}?w=640&h=${getImageHeight(640, content.fields.image)} 640w,
+              ${secureImageUrl}?w=960&h=${getImageHeight(960, content.fields.image)} 960w,
+              ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)} 1280w,
+              ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)} 1920w
+            `"
+            sizes="`
+              calc(100vw - 4rem),
+              (min-width: 600px) calc(100vw - 8rem - 2rem),
+              (min-width: 1220px) calc(1080px - 2rem)
+            `"
+          />
 
           <img
             class="visual__img"
             loading="lazy"
             lazyload="1"
-            :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image)"
+            :src="`${secureImageUrl}?w=1048&h=${getImageHeight(1048, content.fields.image)}`"
             :alt="content.fields.image.fields.title">
         </picture>
       </div>

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -22,13 +22,13 @@
               (min-width: 600px) calc(100vw - 8rem - 2rem),\
               (min-width: 1220px) calc(1080px - 2rem)" />
 
-          <source type="image/jpeg"
+          <source
             :srcset="'\
-              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + '&fm=jpg 320w,\
-              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + '&fm=jpg 640w,\
-              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + '&fm=jpg 960w,\
-              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + '&fm=jpg 1280w,\
-              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + '&fm=jpg 1920w'"
+              '+ secureImageUrl + '?w=320&h=' + getImageHeight(320, content.fields.image) + ' 320w,\
+              '+ secureImageUrl + '?w=640&h=' + getImageHeight(640, content.fields.image) + ' 640w,\
+              '+ secureImageUrl + '?w=960&h=' + getImageHeight(960, content.fields.image) + ' 960w,\
+              '+ secureImageUrl + '?w=1280&h=' + getImageHeight(1280, content.fields.image) + ' 1280w,\
+              '+ secureImageUrl + '?w=1920&h=' + getImageHeight(1920, content.fields.image) + ' 1920w'"
             sizes="\
               calc(100vw - 4rem),\
               (min-width: 600px) calc(100vw - 8rem - 2rem),\
@@ -38,7 +38,7 @@
             class="visual__img"
             loading="lazy"
             lazyload="1"
-            :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image) + '&fm=jpg'"
+            :src="secureImageUrl + '?w=1048&h=' + getImageHeight(1048, content.fields.image)"
             :alt="content.fields.image.fields.title">
         </picture>
       </div>


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-265

We noticed that animated GIFs were getting turned into still images on some browsers. When WebP support is not present, the GIF was getting forced into JPG on our frontend, leading to weirdness.

This PR does less, allowing original media to be displayed in whatever format they were uploaded.

![do-less](https://user-images.githubusercontent.com/254753/64960267-47ecbc80-d893-11e9-9e3c-3cf4bc09652e.gif)
