### PR TITLE
DSR-263: homepage layout

### DIFF
--- a/components/AppBar.vue
+++ b/components/AppBar.vue
@@ -18,7 +18,6 @@
             </li>
             <li class="link--container">
               <SitrepList
-                format="compact"
                 :sitreps="sitreps"
                 v-on:close-menu="closeMenu"
               />
@@ -279,6 +278,11 @@
   // styles from this component and @extending here is the least messy way.
   /deep/ .sitrep-group__heading {
     @extend .link;
+
+    // Now unset some stuff.....
+    display: inline-block;
+    padding-left: 0;
+    margin: 0;
   }
 
   .ocha-services .link {
@@ -338,7 +342,7 @@
 
       input#app-bar__toggle:checked ~ &,
       &.is--expanded {
-        width: 23rem;
+        width: 25rem;
         overflow: hidden;
       }
     }
@@ -348,7 +352,7 @@
     }
 
     .app-bar__content {
-      width: 22rem;
+      width: 24rem;
     }
 
     .ocha-heading {

--- a/components/SitrepList.vue
+++ b/components/SitrepList.vue
@@ -1,6 +1,6 @@
 <template>
-  <ul class="sitrep-list" :class="'format--' + format">
-    <li class="sitrep-group" v-if="format === 'compact'" :key="data[0].sys.id" v-for="data in sorted">
+  <ul class="sitrep-list">
+    <li class="sitrep-group" :key="data[0].sys.id" v-for="data in sorted">
       <span class="sitrep-group__heading" :lang="data[0].fields.language">{{ data[0].fields.title.trim() }}</span>
       <span class="sitrep" :key="sitrep.sys.id" v-for="sitrep in data">
         <nuxt-link
@@ -10,19 +10,6 @@
           v-on:click.native="closeParentMenu"
         >{{ sitrep.fields.language }}</nuxt-link>
       </span>
-    </li>
-    <li class="sitrep-group" v-if="format === 'full'" :key="data[0].sys.id" v-for="data in sorted">
-      <h3 class="sitrep-group__heading">{{ data[0].fields.title.trim() }}</h3>
-      <p class="sitrep" :key="sitrep.sys.id" v-for="sitrep in data">
-        <nuxt-link
-          :to="'/' + sitrep.fields.language + '/country/' + sitrep.fields.slug + '/'"
-          :lang="sitrep.fields.language"
-        >{{ localeName(sitrep.fields.language) }}</nuxt-link>
-        <span class="sitrep__last-updated">
-          <span class="element-invisible">{{ $t('Last updated', locale) }}:</span>
-          <time :datetime="sitrep.fields.dateUpdated" :dir="languageDirection(locale)">{{ $moment(sitrep.fields.dateUpdated).locale(locale).format('D MMM YYYY') }}</time>
-        </span>
-      </p>
     </li>
   </ul>
 </template>
@@ -34,10 +21,9 @@
     mixins: [Global],
 
     props: {
-      'sitreps': Array,
-      'format': {
-        type: String,
-        default: 'full',
+      'sitreps': {
+        type: Array,
+        required: true,
       },
     },
 
@@ -75,7 +61,7 @@
         });
 
         // We'll provide the template with a multidimensional array instead of
-        // the flat one we get form Contentful.
+        // the flat one we get from Contentful.
         let sorted = {};
 
         // For each Sitrep in our sorted list...
@@ -101,114 +87,99 @@
 </script>
 
 <style lang="scss" scoped>
-  //
-  // Import shared variables
-  //
-  @import '~/assets/Global.scss';
+//
+// Import shared variables
+//
+@import '~/assets/Global.scss';
 
+.sitrep-list {
+  margin: 1rem 0;
+  padding: 0;
 
-  .sitrep-list {
-    margin: 1rem 0;
-    padding: 0;
+  [dir="ltr"] & {
+    margin-left: 1.5rem;
   }
-  .sitrep-group {
-    list-style-type: none;
-    margin: 0 0 .5rem 0;
-    padding: 0;
-  }
-  .sitrep-group__heading {
-    text-transform: uppercase;
-    font-family: $roboto-condensed;
-  }
-  .sitrep {
-    margin: .25rem 0;
 
-    //
-    // Although it brings consistency to the various pages, this one rule adds
-    // a 82K font download to the homepage to render a single word. Unless it is
-    // deemed extremely important to retain branding across pages, we are not
-    // applying the Dubai font to the non-Arabic language homepage for now.
-    //
-    // a[lang="ar"] {
-    //   font-family: $dubai;
-    // }
+  [dir="rtl"] & {
+    margin-right: 1.5rem;
   }
-  .sitrep__last-updated {
-    color: #666;
-    font-style: italic;
+}
 
-    [dir="ltr"] & {
-      font-size: .9em;
-    }
+.sitrep-group {
+  list-style-type: none;
+  margin: 0 0 .5rem 0;
+  padding: 0;
+}
 
-    [lang="ar"] & {
-      font-style: normal;
-    }
-  }
+.sitrep-group__heading {
+  text-transform: uppercase;
+  font-family: $roboto;
+}
+
+.sitrep {
+  margin: .25rem 0;
 
   //
-  // Format: Full
+  // Although it brings consistency to the various pages, this one rule adds
+  // a 82K font download to the homepage to render a single word. Unless it is
+  // deemed extremely important to retain branding across pages, we are not
+  // applying the Dubai font to the non-Arabic language homepage for now.
   //
-  .format--full {
-    .sitrep-group__heading {
-      margin-top: 1rem;
-      font-size: 1.1em;
-      color: #666;
-    }
+  // a[lang="ar"] {
+  //   font-family: $dubai;
+  // }
+}
+
+.sitrep__last-updated {
+  color: #666;
+  font-style: italic;
+
+  [dir="ltr"] & {
+    font-size: .9em;
   }
 
-  //
-  // Format: Compact
-  //
-  .format--compact {
-    &.sitrep-list {
-      margin-left: 1.5rem;
+  [lang="ar"] & {
+    font-style: normal;
+  }
+}
 
-      [dir="rtl"] & {
-        margin-left: auto;
-        margin-right: 1.5rem;
-      }
-    }
+.sitrep-group {
+  background-image: url('/icons/icon--location.svg');
+  background-repeat: no-repeat;
+  background-size: 1.25rem 1.25rem;
 
-    .sitrep-group {
-      background-image: url('/icons/icon--location.svg');
-      background-repeat: no-repeat;
-      background-size: 1.25rem 1.25rem;
-
-      [dir="ltr"] & {
-        padding-left: 1.5rem;
-        background-position: 0% 50%;
-      }
-
-      [dir="rtl"] & {
-        padding-right: 1.5rem;
-        background-position: 100% 50%;
-      }
-    }
-
-    .sitrep-group__heading {
-      display: inline;
-      margin: 0 0 .5rem 0;
-      padding-left: 0;
-      font-size: 1em;
-      line-height: 1.5;
-      text-transform: none;
-
-      [dir="rtl"] &[lang="ar"] {
-        padding-left: 1em;
-        padding-right: 4px;
-      }
-    }
-
-    .sitrep {
-      display: inline;
-      margin: 0 .25rem;
-      text-transform: uppercase;
-
-      a {
-        color: white;
-      }
-    }
+  [dir="ltr"] & {
+    padding-left: 1.5rem;
+    background-position: 0% 50%;
   }
 
+  [dir="rtl"] & {
+    padding-right: 1.5rem;
+    background-position: 100% 50%;
+  }
+}
+
+.sitrep-group__heading {
+  display: inline;
+  margin: 0 0 .5rem 0;
+  padding-left: 0;
+  font-size: 1em;
+  line-height: 1.5;
+  text-transform: none;
+
+  [dir="rtl"] &[lang="ar"] {
+    padding-left: 1em;
+    padding-right: 4px;
+  }
+}
+
+.sitrep {
+  display: inline;
+  margin: 0 .25rem;
+  text-transform: uppercase;
+
+  a {
+    color: white;
+  }
+}
 </style>

--- a/components/SitrepList.vue
+++ b/components/SitrepList.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="sitrep-list">
-    <li class="sitrep-group" :key="data[0].sys.id" v-for="data in sorted">
+    <li class="sitrep-group" :key="data[0].sys.id" v-for="data in sortedSitReps(sitreps)">
       <span class="sitrep-group__heading" :lang="data[0].fields.language">{{ data[0].fields.title.trim() }}</span>
       <span class="sitrep" :key="sitrep.sys.id" v-for="sitrep in data">
         <nuxt-link
@@ -24,57 +24,6 @@
       'sitreps': {
         type: Array,
         required: true,
-      },
-    },
-
-    computed: {
-      //
-      // This component requires a very specific structure in order to render the
-      // list with both country names and language options. The basic structure is
-      // an object with slugs as top-level properties, each containing an array of
-      // SitRep translations:
-      //
-      // sitreps (Object)
-      // └ slug (Array)
-      //   └ sitrep (Object)
-      //
-      // Suppose we have two SitReps for Ukraine (en, uk) and one for Burundi (fr)
-      //
-      // sitreps = {
-      //   'burundi': [
-      //     0: {/* SitRep object from Contentful */},
-      //   ],
-      //   'ukraine': [
-      //     0: {/* SitRep object from Contentful */},
-      //     1: {/* SitRep object from Contentful */},
-      //   ],
-      // };
-      //
-      sorted() {
-        // Group entries by Country, sort by dateUpdated, newest first.
-        let tmpList = this.sitreps.slice(0).sort((a, b) => {
-          if (a.fields.slug === b.fields.slug) {
-            // Date is only important when SitReps are the same
-            return new Date(b.fields.dateUpdated) - new Date(a.fields.dateUpdated);
-          }
-          return a.fields.slug > b.fields.slug ? 1 : -1;
-        });
-
-        // We'll provide the template with a multidimensional array instead of
-        // the flat one we get from Contentful.
-        let sorted = {};
-
-        // For each Sitrep in our sorted list...
-        tmpList.forEach((sitrep) => {
-          // If the group already exists...
-          (sorted[sitrep.fields.slug])
-            // Add the current SitRep to the group.
-            ? sorted[sitrep.fields.slug].push(sitrep)
-            // Otherwise begin a new group with the current SitRep.
-            : sorted[sitrep.fields.slug] = [sitrep];
-        });
-
-        return sorted;
       },
     },
 

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -151,6 +151,55 @@
 
         return (rtl.includes(language)) ? 'rtl' : 'ltr';
       },
+
+      //
+      // Lists of SitReps require a very specific structure in order to render the
+      // list with both country names and language options. The basic structure is
+      // an object with slugs as top-level properties, each containing an array of
+      // SitRep translations:
+      //
+      // sitreps (Object)
+      // └ slug (Array)
+      //   └ sitrep (Object)
+      //
+      // Suppose we have two SitReps for Ukraine (en, uk) and one for Burundi (fr)
+      //
+      // sitreps = {
+      //   'burundi': [
+      //     0: {/* SitRep object from Contentful */},
+      //   ],
+      //   'ukraine': [
+      //     0: {/* SitRep object from Contentful */},
+      //     1: {/* SitRep object from Contentful */},
+      //   ],
+      // };
+      //
+      sortedSitReps(sitreps) {
+        // Group entries by Country, sort by dateUpdated, newest first.
+        let tmpList = sitreps.slice(0).sort((a, b) => {
+          if (a.fields.slug === b.fields.slug) {
+            // Date is only important when SitReps are the same
+            return new Date(b.fields.dateUpdated) - new Date(a.fields.dateUpdated);
+          }
+          return a.fields.slug > b.fields.slug ? 1 : -1;
+        });
+
+        // We'll provide the template with a multidimensional array instead of
+        // the flat one we get from Contentful.
+        let sorted = {};
+
+        // For each Sitrep in our sorted list...
+        tmpList.forEach((sitrep) => {
+          // If the group already exists...
+          (sorted[sitrep.fields.slug])
+            // Add the current SitRep to the group.
+            ? sorted[sitrep.fields.slug].push(sitrep)
+            // Otherwise begin a new group with the current SitRep.
+            : sorted[sitrep.fields.slug] = [sitrep];
+        });
+
+        return sorted;
+      },
     }
   }
 </script>

--- a/pages/_lang/index.vue
+++ b/pages/_lang/index.vue
@@ -9,7 +9,7 @@
 
     <main class="container basic-page">
       <h2 class="card__title">{{ $t('Situation Reports', locale) }}</h2>
-      <div class="sitrep-listing--grid">
+      <div class="sitrep-listing--grid clearfix">
         <article class="card card--office" :key="office[0].sys.id" v-for="office in sortedSitReps(sitreps)">
           <h2>{{ office[0].fields.title }}</h2>
           <p class="sitrep" :key="translation.sys.id" v-for="translation in office">
@@ -128,12 +128,10 @@
 // Legacy layout: float
 //——————————————————————————————————————————————————————————————————————————————
 .card--office {
-  width: 30%;
-  margin-right: 5%; // (100 - 30% width * 3 cols) / 2 gaps
-
-  &:nth-child(3n) {
-    margin-left: 0;
-  }
+  float: left;
+  min-width: 339px;
+  margin: .5rem 10px;
+  height: 150px;
 }
 
 
@@ -150,6 +148,7 @@
   .card--office {
     float: none;
     width: auto;
+    height: auto;
     margin: 0;
   }
 

--- a/pages/_lang/index.vue
+++ b/pages/_lang/index.vue
@@ -7,17 +7,10 @@
       :title-is-multilingual="true"
     />
 
-    <main class="container basic-page is--multicolumn">
-      <section class="card card--content" ref="column1">
-        <h2 class="card__title">{{ $t('Recently updated', locale) }}</h2>
-        <SitrepList
-          format="full"
-          :sitreps="sitreps"
-        />
-      </section>
-      <section class="card card--sidebar" ref="column2">
-        <h2 class="card__title">{{ $t('About this site', locale) }}</h2>
-        <div class="rich-text" v-html="richBody"></div>
+    <main class="container basic-page">
+      <section class="card card--content">
+        <h2 class="card__title">{{ $t('All Digital Situation Reports', locale) }}</h2>
+        <p>New listing TBD</p>
       </section>
     </main>
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-263

The list grew. Time to tame it.

The `SitrepList` component used to serve two different use-cases. One was as a very compact list inside the AppBar, and the other was a more detail-rich list on the homepage. This PR cuts the component down so it's only used inside the AppBar, but the one function that truly needed to be shared between the two contexts was moved out to `_Global.vue`.

The homepage got reconstructed using some of the old markup, but the two components are no longer housed inside one Vue file, meaning future adjustments or redesigns will be far simpler.

The homepage is now grows from being single column on mobile to 3-column grid at its widest, with french-language DRC being used as the calibration for when to break the grid into more columns. IE11 of course has its float-based fallback.

The "About this Site" text has been removed from the homepage completely, since it lives at its own URL accessible in the footer of every page.

![image](https://user-images.githubusercontent.com/254753/64971836-9062a500-d8a8-11e9-9153-ec79b970ff9b.png)
