### PR TITLE
DSR-264: Custom RW Archive URL

### DIFF
--- a/_migrations/18-update-sitrep--custom-archive.js
+++ b/_migrations/18-update-sitrep--custom-archive.js
@@ -1,0 +1,26 @@
+module.exports = function(migration) {
+  const sitrep = migration.editContentType('sitrep')
+
+  //
+  // Field: customArchive
+  //
+  // An optional URL field to create a custom RW Archive link.
+  //
+  sitrep
+    .createField('customArchive')
+    .name('Custom ReliefWeb Archive URL')
+    .type('Symbol')
+    .required(false)
+    .validations([
+      {
+        "regexp": {
+          "pattern": "^https:\\/\\/reliefweb\\.int\\/updates\\?search\\="
+        },
+        "message": "MUST begin with https://reliefweb.int/updates?search="
+      }
+    ])
+
+  sitrep
+    .moveField('customArchive')
+    .afterField('article')
+};

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -13,7 +13,7 @@
         <span class="subtitle" v-else aria-hidden="true">&nbsp;</span>
 
         <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(locale).format('D MMM YYYY') }}</time></span>
-        <span class="past-sitreps" v-if="countrycode"><a :href="pastReports" target="_blank" rel="noopener">({{ $t('Archive', locale) }})</a></span>
+        <span class="past-sitreps" v-if="countrycode || customArchive"><a :href="archiveLink" target="_blank" rel="noopener">({{ $t('Archive', locale) }})</a></span>
       </div>
     </div>
 
@@ -80,6 +80,11 @@
       'updated': String,
       'mailchimp': String,
       'countrycode': String,
+      'customArchive': {
+        type: String,
+        required: false,
+        default: '',
+      },
       'translations': Array,
       'share': Boolean,
       'snap': Boolean,
@@ -138,8 +143,19 @@
         return this.$moment(Date.now()).locale(this.locale).format('D MMM YYYY');
       },
 
-      pastReports() {
-        return `https://reliefweb.int/updates?search=primary_country.iso3:${this.countrycode} AND ocha_product:("Humanitarian Bulletin" OR "Situation Report" OR "Flash Update") AND source:OCHA#content`;
+      archiveLink() {
+        let archiveLink;
+
+        // When a custom link is provided, use its value.
+        if (this.customArchive) {
+          archiveLink = this.customArchive;
+        }
+        else {
+          // By default we use `countryCode` to create the archive link
+          archiveLink = `https://reliefweb.int/updates?search=primary_country.iso3:${this.countrycode} AND ocha_product:("Humanitarian Bulletin" OR "Situation Report" OR "Flash Update") AND source:OCHA#content`;
+        }
+
+        return archiveLink;
       },
 
       shareBaseUrl() {

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -8,6 +8,7 @@
       :updated="entry.fields.dateUpdated"
       :mailchimp="entry.fields.mailchimpSignup"
       :countrycode="entry.fields.countryCode"
+      :custom-archive="entry.fields.customArchive"
       :translations="translations"
       :share="true"
       :snap="true" />


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-264

ROs were requesting the ability to create custom RW archive links, so that multiple countries' worth of products can be shown in their "Archive" link of the SitRep `AppHeader` component.

When `customArchive` field is populated, that URL is used. Otherwise the standard ISO3 is used to construct the normal URL. There is CTF validation to ensure it points only to RW archive page and no other URL can be input.