### PR TITLE
DSR-182: show absolute/relative timestamps based on context

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -4,8 +4,9 @@
 
     <span class="card__title">
       <span class="card__heading">{{ $t(content.fields.sectionHeading, locale) }}</span>
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </span>
+
     <div
       class="article__content"
       :class="{ 'article__content--has-image': articleHasImage }"

--- a/components/Cluster.vue
+++ b/components/Cluster.vue
@@ -4,7 +4,7 @@
 
     <h2 class="card__title">
       {{ sectionHeading }}
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </h2>
     <div class="cluster__meta clearfix">
       <h3 class="cluster__title" :class="clusterIconClasses">{{ content.fields.clusterName }}</h3>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -8,7 +8,7 @@
 
     <span class="card__title">
       <span class="card__heading">{{ $t('Flash Update', locale) }}</span>
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </span>
 
     <div

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -4,7 +4,7 @@
 
     <span class="card__title">
       {{ $t('Interactive', locale) }}
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </span>
     <div class="interactive__content">
       <div class="interactive__text">

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -4,7 +4,7 @@
 
     <h2 class="card__title">
       {{ $t('Funding', locale) }}
-      <span v-if="ftsDataYear" class="card__time-ago">({{ ftsDataYear }})</span>
+      <time v-if="ftsDataYear" :datetime="ftsDataYear" class="card__time-ago">({{ ftsDataYear }})</time>
     </h2>
     <div class="figures clearfix">
       <figure v-if="ftsData.length" v-for="figure in ftsData" :key="figure.sys.id" :class="{'figure--progress': figure.fields.type === 'progress'}">
@@ -168,6 +168,13 @@
   // Import shared variables
   //
   @import '~/assets/Global.scss';
+
+  // By default most timestamps are now clickable. This one isn't.
+  //
+  // @see DSR-182
+  .card__time-ago {
+    cursor: default;
+  }
 
   // The size of the pie chart is needed by a few definitions in this component.
   // Defined in pixels.

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -4,7 +4,7 @@
 
     <h2 class="card__title">
       {{ $t('Highlights', locale) }}
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </h2>
     <div class="key-messages__area">
       <ul class="message-list">
@@ -73,17 +73,6 @@
       'image': Object,
     },
 
-    data() {
-      return {
-        // updatedAt is the first index of the sorted array of timestamps.
-        updatedAt: this.messages.map((msg) => {
-          return msg.sys.updatedAt
-        }).sort((b, a) => {
-          return a < b ? -1 : (a > b ? 1 : 0);
-        })[0],
-      }
-    },
-
     computed: {
       cssId() {
         return 'highlights';
@@ -95,6 +84,16 @@
 
       secureImageUrl() {
         return 'https:' + this.image.fields.file.url;
+      },
+
+      // For Highlights each message has its own timestamp, so sort all of them
+      // by date and use the newest timestamp for the whole card.
+      updatedAt() {
+        return this.messages.map((msg) => {
+          return msg.sys.updatedAt
+        }).sort((b, a) => {
+          return a < b ? -1 : (a > b ? 1 : 0);
+        })[0];
       },
     },
   }

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -4,7 +4,7 @@
 
     <span class="card__title">
       {{ $t('Media', locale) }}
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </span>
     <div class="video__content">
       <div class="video__embed" v-if="content.fields.videoUrl">

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -4,7 +4,7 @@
 
     <span class="card__title">
       {{ $t('Visual', locale) }}
-      <span class="card__time-ago">({{ formatTimeAgo }})</span>
+      <time :datetime="updatedAt" class="card__time-ago" @click="toggleTimestampFormatting">({{ timestamp }})</time>
     </span>
     <div class="visual__content">
       <h3 class="visual__title">{{ content.fields.title }}</h3>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -189,6 +189,37 @@
         // flip our bit.
         this.formatTimestamps = !this.formatTimestamps;
       },
-    }
+    },
+
+    //
+    // Client-side ONLY: disable timestamp formatting when Snap is detected
+    //
+    // We do this by checking for the Snap class that gets injected, and reacting
+    // to it.
+    //
+    // TODO: Maybe this is better as a MutationObserver?
+    //
+    mounted() {
+      // Allow references to this component in setTimeout/setInterval.
+      const GlobalMixin = this;
+
+      // Setup detection and store ID.
+      var detectId = setInterval(detectSnapClass, 33);
+
+      function detectSnapClass() {
+        // If we detect the Snap class, disable relative timestamps and stop
+        // running the detection function.
+        if (document.documentElement.className.indexOf('snap') !== -1) {
+          GlobalMixin.formatTimestamps = false;
+          clearInterval(detectId);
+        }
+      }
+
+      // Kill the detection after some time has passed. This is for regular
+      // users so their JS thread doesn't have this running indefinitely.
+      setTimeout(function () {
+        clearInterval(detectId);
+      }, 10000)
+    },
   }
 </script>

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -4,6 +4,7 @@
       return {
         // Options or custom methods for rendering Contentful RichText fields.
         renderOptions: {},
+        formatTimestamps: true,
       }
     },
 
@@ -62,6 +63,13 @@
 
         // Return our formatted, translated timestamp
         return translated;
+      },
+
+      //
+      // Toggle-able timestamps
+      //
+      timestamp() {
+        return this.formatTimestamps ? this.formatTimeAgo : this.$moment(this.updatedAt).locale(this.locale).format('D MMM YYYY');
       },
 
       //
@@ -169,6 +177,17 @@
         ];
 
         return (rtl.includes(language)) ? 'rtl' : 'ltr';
+      },
+
+      //
+      // Toggles formatting of timestamps.
+      //
+      toggleTimestampFormatting(ev) {
+        // We want to avoid bringing focus to the card itself.
+        ev.stopPropagation();
+
+        // flip our bit.
+        this.formatTimestamps = !this.formatTimestamps;
       },
     }
   }

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -25,24 +25,43 @@
 
       // Format the duration since the Entry was published.
       formatTimeAgo() {
+        // Start by formatting in minutes. If no other conditional applies as
+        // we progress through this function, it will output minutes.
         let duration = this.timeAgoInMinutes;
         let units = (duration === 1) ? 'minute' : 'minutes';
 
-        if (duration > 1440) {
+        // Months (we consider anything more than 4 weeks a month)
+        if (duration > 40320) {
+          duration = Math.floor(duration / 40320);
+          units = (duration === 1) ? 'month' : 'months';
+        }
+        // Weeks
+        else if (duration > 10080) {
+          duration = Math.floor(duration / 10080);
+          units = (duration === 1) ? 'week' : 'weeks';
+        }
+        // Days
+        else if (duration > 1440) {
           duration = Math.floor(duration / 1440);
           units = (duration === 1) ? 'day' : 'days';
         }
+        // Hours
         else if (duration > 60) {
           duration = Math.floor(duration / 60);
           units = (duration === 1) ? 'hour' : 'hours';
         }
 
+        // Translate
+        //
         // This is done in two steps. Our translations are supplied with the
         // literal string `#` in them, so we first translate then replace
         // with the dynamic value of #. That substitution could also be
         // localized if we want to maintain a list.
         const value = /\#/gi;
-        return this.$t(`# ${units} ago`, this.locale).replace(value, duration);
+        const translated = this.$t(`# ${units} ago`, this.locale).replace(value, duration);
+
+        // Return our formatted, translated timestamp
+        return translated;
       },
 
       //

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -31,8 +31,13 @@
         let duration = this.timeAgoInMinutes;
         let units = (duration === 1) ? 'minute' : 'minutes';
 
-        // Months (we consider anything more than 4 weeks a month)
-        if (duration > 40320) {
+        // Years (> 365 days)
+        if (duration > 525600) {
+          duration = Math.floor(duration / 525600);
+          units = (duration === 1) ? 'year' : 'years';
+        }
+        // Months (> 4 weeks)
+        else if (duration > 40320) {
           duration = Math.floor(duration / 40320);
           units = (duration === 1) ? 'month' : 'months';
         }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -569,6 +569,7 @@ figure picture ~ figcaption {
   opacity: .8;
   font-weight: 400;
   text-transform: none;
+  cursor: pointer;
 
   [lang="ar"] & {
     font-family: $kufi;

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': 'منذ # ساعة',
   '# day ago': 'منذ يوم',
   '# days ago': 'منذ # يوم',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/locales/en.js
+++ b/locales/en.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/en.js
+++ b/locales/en.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': '# hours ago',
   '# day ago': '# day ago',
   '# days ago': '# days ago',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/locales/es.js
+++ b/locales/es.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/es.js
+++ b/locales/es.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': 'Hace # horas',
   '# day ago': 'Hace # día',
   '# days ago': 'Hace # días',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': 'Il y a # heures',
   '# day ago': 'Il y a # jour',
   '# days ago': 'Il y a # jours',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': '# часа/часов назад',
   '# day ago': '# день назад',
   '# days ago': '# дня/дней назад',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -122,4 +122,6 @@ export default {
   '# weeks ago': '# weeks ago',
   '# month ago': '# month ago',
   '# months ago': '# months ago',
+  '# year ago': '# year ago',
+  '# years ago': '# years ago',
 }

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -118,4 +118,8 @@ export default {
   '# hours ago': '# години/годин тому',
   '# day ago': '# день тому',
   '# days ago': '# дня/дні тому',
+  '# week ago': '# week ago',
+  '# weeks ago': '# weeks ago',
+  '# month ago': '# month ago',
+  '# months ago': '# months ago',
 }

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -222,6 +222,9 @@
         this.ftsData = (this.ftsData.length) ? this.ftsData : response.ftsData;
       });
 
+      //
+      // When a document fragment is in the window.location.hash, scroll to it
+      //
       if (window.location.hash) {
         setTimeout(() => {
           // Scroll/jump to element according to browser capability.
@@ -232,6 +235,57 @@
             preventScroll: true,
           });
         }, 500);
+      }
+
+      //
+      // Disable timestamp formatting when Snap is detected.
+      //
+      // This browser feature  actually has 100% support within our matrix, but
+      // no need to cause trouble in older browsers.
+      //
+      // @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+      //
+      if (window && "MutationObserver" in window) {
+        //
+        // Target of MutationOberver
+        //
+        // Must match the element targeted by the Snap Service. The other repo is
+        // always the canonical source of truth for which element should be loaded
+        // into this variable.
+        //
+        // The line in question at the time of writing this comment is linked for
+        // reference. If that repo gets updated, update this block with new link.
+        //
+        // @see https://github.com/UN-OCHA/tools-snap-service/blob/e68e6ffda5cb0d607f290cba4d7a45b4ff175e16/app/app.js#L470
+        //
+        const mutationTarget = document.documentElement;
+
+        // Configure MutationOberver
+        const mutationConfig = {attributes: true};
+
+        // Store `this` in a variable to access within MutationObserver.
+        const page = this;
+
+        // Callback when Snap class is detected
+        const mutationCallback = function(mutationsList, oberver) {
+          for (let mutation of mutationsList) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+              if (mutation.target.className.indexOf('snap') !== -1) {
+                // Disable timestamp formatting *for the entire page* by updating
+                // the Vuex store. In theory this is a short-lived page-view that
+                // only gets triggered by Snap Service so the app doesn't provide
+                // a way to "undo" the change we're making here.
+                page.$store.commit('SET_GLOBAL_TIMESTAMP_FORMATTING', false);
+              }
+            }
+          }
+        }
+
+        // Create MutationOberver
+        const observer = new MutationObserver(mutationCallback);
+
+        // Start observing
+        observer.observe(mutationTarget, mutationConfig);
       }
     },
 

--- a/store/index.js
+++ b/store/index.js
@@ -39,6 +39,9 @@ export const state = () => ({
   appbar: {
     isExpanded: false,
   },
+  globalFormatting: {
+    formatTimestamps: 'auto',
+  },
 });
 
 export const mutations = {
@@ -59,5 +62,9 @@ export const mutations = {
     state.appbar = {
       isExpanded: bool,
     }
+  },
+
+  SET_GLOBAL_TIMESTAMP_FORMATTING(state, setting) {
+    state.globalFormatting.formatTimestamps = setting;
   },
 };


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-182

We had two use-cases:

1. Our PNG/PDF artifacts had relative "X days ago" timestamps that made no sense when uploaded to historical archives, social media, or email campaigns. That needed to be fixed.
2. Once the ability to toggle was there, attaching a click handler to each timestamp was trivial, to allow toggling on the page itself if people wish it.

The PR adds the following:

- New units for relative timestamps: week/month/year (translations all pending and set to English for the time being)
- Event listener on timestamps to allow click-to-toggle. Default is still relative timestamp.
- A new property in the Vuex store to control site-wide timestamp formatting.
- A MutationObserver on the `<html>` element that listens for Snap Service to inject one of its classes. When the listener is triggered, it sets the site-wide formatting flag in Vuex. The store overrides the individual settings of each component.