### PR TITLE
DSR-273: limit display of languages on generic pages

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -25,6 +25,7 @@
         <div class="lang-switcher" dir="ltr">
           <span class="lang-switcher__label element-invisible">{{ $t('Read this Situation Report in a different language:', locale) }}</span>
           <nuxt-link v-for="translation in availableTranslations"
+            v-if="translation.display === true"
             :key="translation.code"
             :to="'/' + translation.code + '/' + urlContext"
             :class="[

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -461,7 +461,8 @@
       // Reformat CTF translations response so follows format of locales Store.
       let translations = translationEntries.items.map((translation) => {
         return {
-          'code': translation.fields.language,
+          code: translation.fields.language,
+          display: true,
         }
       });
 

--- a/store/index.js
+++ b/store/index.js
@@ -1,44 +1,82 @@
 export const state = () => ({
-  locale: 'en',
+  //
+  // Define each Language
+  //
+  // code: this is the ISO 2-character language code. We don't support locales,
+  //     despite the name of all the variables below.
+  //
+  // name: the language's own name for itself. Our translation files contain the
+  //     specific names of each language.
+  //
+  // dir: the reading direction as it pertains to HTML. The two options are
+  //     * ltr - left-to-right
+  //     * rtl - right-to-left
+  //
+  // display: a DSR-specific property that sets a default which controls generic
+  //     pages such as home/about/etc. These pages only feature the languages in
+  //     the "UN 6" group, but can still be rendered in other languages when
+  //     navigating from a SitRep or a direct URL.
+  //
+  //     When a SitRep is authored in multiple languages the property is always
+  //     forced to `true`, meaning the language selection of SitReps is based
+  //     solely on what languages the Offices have authored their content in.
+  //
   locales: [
     {
       code: 'en',
       name: 'English',
       dir: 'ltr',
+      display: true,
     },
     {
       code: 'es',
       name: 'Español',
       dir: 'ltr',
+      display: true,
     },
     {
       code: 'fr',
       name: 'Français',
       dir: 'ltr',
+      display: true,
     },
     {
       code: 'ru',
       name: 'Русский',
       dir: 'ltr',
+      display: true,
     },
     {
       code: 'uk',
       name: 'Українська',
       dir: 'ltr',
+      display: false,
     },
     {
       code: 'ar',
       name: 'عربي',
       dir: 'rtl',
+      display: true,
     },
   ],
+
+  // Default site language. Changing this will break our translation system.
+  locale: 'en',
+
+  // Allow sub-components of a SitRep to display the Title/Date of a SitRep by
+  // holding the current URL's metadata in the store. Primarily used by Snap PNGs.
   reportMeta: {
     title: '',
     dateUpdated: '',
   },
+
+  // Lets the whole app know about the AppBar state.
   appbar: {
     isExpanded: false,
   },
+
+  // Lets the whole app render dates consistently when context requires it.
+  // e.g. Used by Snaps to render PDF/PNGs with absolute dates.
   globalFormatting: {
     formatTimestamps: 'auto',
   },

--- a/store/index.js
+++ b/store/index.js
@@ -22,6 +22,9 @@ export const state = () => ({
   //     solely on what languages the Offices have authored their content in.
   //
   locales: [
+    //
+    // Official UN Translations
+    //
     {
       code: 'en',
       name: 'English',
@@ -47,16 +50,27 @@ export const state = () => ({
       display: true,
     },
     {
-      code: 'uk',
-      name: 'Українська',
-      dir: 'ltr',
-      display: false,
-    },
-    {
       code: 'ar',
       name: 'عربي',
       dir: 'rtl',
       display: true,
+    },
+    // {
+    //   code: 'zh',
+    //   name: '中文',
+    //   dir: 'ltr', // Following www.un.org/zh/ for direction
+    //   display: true,
+    // },
+
+    //
+    // Non-default languages.
+    // All languages below this comment should have `display: false`
+    //
+    {
+      code: 'uk',
+      name: 'Українська',
+      dir: 'ltr',
+      display: false,
     },
   ],
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-273

SitReps still show the full set of translations that an office has created.