### PR TITLE
DSR-272: remove anchors from PDFs entirely

### DIFF
--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -163,7 +163,7 @@
       },
 
       pdfUrl() {
-        return process.client ? window.location.href + 'flash-update/' + this.content.sys.id + '/' : '#';
+        return process.client ? window.location.origin + window.location.pathname + 'flash-update/' + this.content.sys.id + '/' : '#';
       },
     },
 

--- a/components/Snap.vue
+++ b/components/Snap.vue
@@ -28,7 +28,7 @@
 
     computed: {
       defaultSitRepUrl() {
-        return window.location.href;
+        return window.location.origin + window.location.pathname;
       },
 
       snapEndpoint() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -542,9 +542,11 @@ figure picture ~ figcaption {
     padding: 0 0 1rem 0;
   }
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 4px $main-blue;
+  @media screen {
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 4px $main-blue;
+    }
   }
 }
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/DSR-272

The original ticket had to do with the outline from the anchor, but i nits current form the PDF is always of the entire URL and not a specific anchor. Removing them from the PDF footer seemed best to me.

I also wrapped the outline in a `@media screen` just to be double-sure that it never shows up in a PDF.