### PR TITLE
DSR-273: followup to restore translations on About

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -127,9 +127,7 @@
         // NOTE: We do the JSON stringify/parse on this.locales to avoid passing
         //       by reference which would lead to a fatal Vuex mutation error
         //       when we run the sort() method.
-        let available = this.translations || JSON.parse(JSON.stringify(this.locales));
-
-        return available.sort();
+        return this.translations || JSON.parse(JSON.stringify(this.locales));
       },
 
       urlContext() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",

--- a/pages/_lang/_slug.vue
+++ b/pages/_lang/_slug.vue
@@ -145,10 +145,13 @@
           language: lang,
         });
 
-        // Reformat CTF translations response so follows format of locales Store.
+        // Reformat CTF translations response to follow format of locales Store.
         let translations = translationEntries.items.map((translation) => {
           return {
             'code': translation.fields.language,
+            // neither `this` nor Global.methods seemed to be avilable within
+            // asyncData so we hardcode the UN 6.
+            'display': ['en','es','fr','ru','ar','zh'].includes(translation.fields.language),
           }
         });
 


### PR DESCRIPTION
## DSR-273

I noticed that About had lost its translations. This should restore them and also provide an accurate sorted list on other pages we might add in the future.

There's one remaining cosmetic issue, and that's the order which the translations display. It's dependent on last-edited time in Contentful. I tried briefly to unify the ordering but couldn't come up with a quick solution. I'll ticket the need for a longer-term fix.