### PR TITLE
DSR-286: better validation for SitRep minimum content

### DIFF
--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -419,14 +419,23 @@
         if (typeof entries.items[0].fields.keyMessagesImage.fields === 'undefined') {
           problems.push('keyMessagesImage contains no published asset');
         }
-        if (typeof entries.items[0].fields.keyMessages === 'undefined' || !entries.items[0].fields.keyMessages.some(haveFields)) {
-          problems.push('keyMessages field contains no published entries');
+        if (typeof entries.items[0].fields.keyMessages === 'undefined') {
+          problems.push('keyMessages field contains nothing');
         }
-        if (typeof entries.items[0].fields.keyFigure === 'undefined' || !entries.items[0].fields.keyFigure.some(haveFields)) {
-          problems.push('keyFigure field contains no published entries');
+        if (typeof entries.items[0].fields.keyMessages !== 'undefined' && !entries.items[0].fields.keyMessages.some(haveFields)) {
+          problems.push('keyMessages field contains unpublished entries');
         }
-        if (typeof entries.items[0].fields.contacts === 'undefined' || !entries.items[0].fields.contacts.some(haveFields)) {
-          problems.push('contacts field contains no published entries');
+        if (typeof entries.items[0].fields.keyFigure === 'undefined') {
+          problems.push('keyFigure field contains nothing');
+        }
+        if (typeof entries.items[0].fields.keyFigure !== 'undefined' && !entries.items[0].fields.keyFigure.some(haveFields)) {
+          problems.push('keyFigure field contains unpublished entries');
+        }
+        if (typeof entries.items[0].fields.contacts === 'undefined') {
+          problems.push('contacts field contains nothing');
+        }
+        if (typeof entries.items[0].fields.contacts !== 'undefined' && !entries.items[0].fields.contacts.some(haveFields)) {
+          problems.push('contacts field contains unpublished entries');
         }
 
         throw ({

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -402,8 +402,11 @@
       //
       if (
         typeof entries.items[0].fields.keyMessagesImage.fields !== 'undefined' &&
+        typeof entries.items[0].fields.keyMessages !== 'undefined' &&
         entries.items[0].fields.keyMessages.some(haveFields) &&
+        typeof entries.items[0].fields.keyFigure !== 'undefined' &&
         entries.items[0].fields.keyFigure.some(haveFields) &&
+        typeof entries.items[0].fields.contacts !== 'undefined' &&
         entries.items[0].fields.contacts.some(haveFields)
       ) {
         // All content checks passed. Continue with execution.
@@ -416,13 +419,13 @@
         if (typeof entries.items[0].fields.keyMessagesImage.fields === 'undefined') {
           problems.push('keyMessagesImage contains no published asset');
         }
-        if (!entries.items[0].fields.keyMessages.some(haveFields)) {
+        if (typeof entries.items[0].fields.keyMessages === 'undefined' || !entries.items[0].fields.keyMessages.some(haveFields)) {
           problems.push('keyMessages field contains no published entries');
         }
-        if (!entries.items[0].fields.keyFigure.some(haveFields)) {
+        if (typeof entries.items[0].fields.keyFigure === 'undefined' || !entries.items[0].fields.keyFigure.some(haveFields)) {
           problems.push('keyFigure field contains no published entries');
         }
-        if (!entries.items[0].fields.contacts.some(haveFields)) {
+        if (typeof entries.items[0].fields.contacts === 'undefined' || !entries.items[0].fields.contacts.some(haveFields)) {
           problems.push('contacts field contains no published entries');
         }
 


### PR DESCRIPTION
## DSR-286

We had a SitRep published with no Key Figures. The website had a sad and did not report the problem in our logs. This protects against it, while simultaneously adjusting some Contentful validation to ensure that it won't happen again.