### PR TITLE
DSR-286: better error handling for KeyFigures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -404,8 +404,8 @@
         typeof entries.items[0].fields.keyMessagesImage.fields !== 'undefined' &&
         typeof entries.items[0].fields.keyMessages !== 'undefined' &&
         entries.items[0].fields.keyMessages.some(haveFields) &&
-        typeof entries.items[0].fields.keyFigure !== 'undefined' &&
-        entries.items[0].fields.keyFigure.some(haveFields) &&
+        // typeof entries.items[0].fields.keyFigure !== 'undefined' &&
+        // entries.items[0].fields.keyFigure.some(haveFields) &&
         typeof entries.items[0].fields.contacts !== 'undefined' &&
         entries.items[0].fields.contacts.some(haveFields)
       ) {
@@ -425,12 +425,12 @@
         if (typeof entries.items[0].fields.keyMessages !== 'undefined' && !entries.items[0].fields.keyMessages.some(haveFields)) {
           problems.push('keyMessages field contains unpublished entries');
         }
-        if (typeof entries.items[0].fields.keyFigure === 'undefined') {
-          problems.push('keyFigure field contains nothing');
-        }
-        if (typeof entries.items[0].fields.keyFigure !== 'undefined' && !entries.items[0].fields.keyFigure.some(haveFields)) {
-          problems.push('keyFigure field contains unpublished entries');
-        }
+        // if (typeof entries.items[0].fields.keyFigure === 'undefined') {
+        //   problems.push('keyFigure field contains nothing');
+        // }
+        // if (typeof entries.items[0].fields.keyFigure !== 'undefined' && !entries.items[0].fields.keyFigure.some(haveFields)) {
+        //   problems.push('keyFigure field contains unpublished entries');
+        // }
         if (typeof entries.items[0].fields.contacts === 'undefined') {
           problems.push('contacts field contains nothing');
         }


### PR DESCRIPTION
## DSR-286

Follow-up to allow KeyFigures to display "No data available"