### PR TITLE
DSR-284: parse sizes attributes of <picture> tags

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -21,7 +21,7 @@
                 ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)}&fm=webp 826w,
                 ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)}&fm=webp 1239w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 900px) calc((1080px - 2rem) * .4),
@@ -36,7 +36,7 @@
                 ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)} 826w,
                 ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)} 1239w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 900px) calc((1080px - 2rem) * .4),

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -25,7 +25,7 @@
                 ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)}&fm=webp 826w,
                 ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)}&fm=webp 1239w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 900px) calc((1080px - 2rem) * .4),
@@ -40,7 +40,7 @@
                 ${secureImageUrl}?w=826&h=${getImageHeight(826, content.fields.image)} 826w,
                 ${secureImageUrl}?w=1239&h=${getImageHeight(1239, content.fields.image)} 1239w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 900px) calc((1080px - 2rem) * .4),

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -27,7 +27,7 @@
                 ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)}&fm=webp 1280w,
                 ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)}&fm=webp 1920w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 1220px) calc(1080px - 2rem)
@@ -42,7 +42,7 @@
                 ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)} 1280w,
                 ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)} 1920w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 1220px) calc(1080px - 2rem)

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -22,7 +22,7 @@
                 ${secureImageUrl}?w=800&h=${getImageHeight(800, image)}&fm=webp 800w,
                 ${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)}&fm=webp 1032w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 800px) calc((100vw - 10rem) / 2),
@@ -36,7 +36,7 @@
                 ${secureImageUrl}?w=800&h=${getImageHeight(800, image)} 800w,
                 ${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)} 1032w
               `"
-              sizes="`
+              :sizes="`
                 calc(100vw - 4rem),
                 (min-width: 600px) calc(100vw - 8rem - 2rem),
                 (min-width: 800px) calc((100vw - 10rem) / 2),

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -18,7 +18,7 @@
               ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)}&fm=webp 1280w,
               ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)}&fm=webp 1920w
             `"
-            sizes="`
+            :sizes="`
               calc(100vw - 4rem),
               (min-width: 600px) calc(100vw - 8rem - 2rem),
               (min-width: 1220px) calc(1080px - 2rem)
@@ -32,7 +32,7 @@
               ${secureImageUrl}?w=1280&h=${getImageHeight(1280, content.fields.image)} 1280w,
               ${secureImageUrl}?w=1920&h=${getImageHeight(1920, content.fields.image)} 1920w
             `"
-            sizes="`
+            :sizes="`
               calc(100vw - 4rem),
               (min-width: 600px) calc(100vw - 8rem - 2rem),
               (min-width: 1220px) calc(1080px - 2rem)


### PR DESCRIPTION
## DSR-284

During #274 I introduced a regression in the handling of the `sizes` attribute of the picture tags. Commit eb9531f switched to template literals but the attribute wasn't prefixed with a colon, causing the HTML to contain the back-ticks.