### PR TITLE
DSR-279: show 404 at /LANG/country/

### DIFF
--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -87,7 +87,7 @@
     // Validate URL params
     validate({params, query, store}) {
       const langIsValid = !!store.state.locales.find((lang) => lang.code === params.lang);
-      const slugIsValid = /^[a-z\-]+$/.test(params.slug);
+      const slugIsValid = !!params.slug && /^[a-z\-]+$/.test(params.slug);
 
       return slugIsValid && langIsValid;
     },


### PR DESCRIPTION
## DSR-279

Lacking a sitrep slug should show an error instead of treating it as a `SELECT *` type query.

Now instead of a random SitRep with 30-something redundant language choices, you get a 404.