### PR TITLE
DSR-246: FlashUpdate displays CardUrl button like other Cards

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -78,7 +78,12 @@
       {{ isExpanded ? $t('Read less', locale) : $t('Read more', locale) }}
     </button>
 
-    <CardActions :label="content.fields.sectionHeading" :css-id="cssIdSelector" :sys-id="sysId" :showUrl="true" />
+    <CardActions
+      :label="content.fields.sectionHeading"
+      :css-id="cssIdSelector"
+      :sys-id="sysId"
+      :showUrl="true"
+    />
     <CardFooter />
   </article>
 </template>

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -85,6 +85,8 @@
     <CardActions
       label="Flash Update"
       :css-id="cssIdSelector"
+      :sys-id="sysId"
+      :show-url="showUrl"
       :show-png="showPng"
       :show-pdf="showPdf"
       :title="$store.state.reportMeta.title"
@@ -121,6 +123,11 @@
         type: Boolean,
         required: false,
         default: false,
+      },
+      'showUrl': {
+        type: Boolean,
+        required: false,
+        default: true,
       },
       'showPng': {
         type: Boolean,


### PR DESCRIPTION
## DSR-246

The FlashUpdate didn't yet sport the 🔗 button allowing people to copy the standalone URL to the clipboard. Now it does.