### PR TITLE
DSR-275: user feedback when copying URL

### DIFF
--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -110,23 +110,23 @@
     position: absolute;
     top: 1rem;
     line-height: 1;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-end;
+    align-items: stretch;
 
     [dir="ltr"] & {
-      right: 1rem;
+      right: .55rem;
     }
-
     [dir="rtl"] & {
-      left: 1rem;
+      left: .55em;
     }
 
-    // Give each button some breathing room.
-    > * {
-      [dir="ltr"] & {
-        margin-left: .5rem;
-      }
-      [dir="rtl"] & {
-        margin-right: .5rem;
-      }
+    // Individual buttons
+    * {
+      flex-shrink: 0;
+      flex-grow: 0;
+      flex-basis: 32px;
     }
   }
 

--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -1,7 +1,9 @@
 <template>
   <a
     class="btn btn--link"
+    :class="{'is--showing-success': showSuccessMessage}"
     :title="buttonText"
+    :data-message="'URL Copied!'"
     :href="buttonHref"
     @click="copyUrlToClipboard">
     <span class="element-invisible">{{ buttonText }}</span>
@@ -27,6 +29,12 @@
         type: String,
         required: true,
       },
+    },
+
+    data() {
+      return {
+        showSuccessMessage: false,
+      };
     },
 
     computed: {
@@ -61,7 +69,18 @@
         const link = this.buttonHref;
 
         // Copy to clipboard
-        clipboard.writeText(link);
+        clipboard
+          .writeText(link)
+          .then(data => {
+            // Display user feedback for the duration specified in setTimeout.
+            this.showSuccessMessage = true;
+            setTimeout(() => {
+              this.showSuccessMessage = false;
+            }, 3000);
+          })
+          .catch(err => {
+            console.error(err);
+          });
       },
     }
   }
@@ -81,5 +100,54 @@
     background-repeat: no-repeat;
     background-size: 1rem 1rem;
     cursor: copy;
+    position: relative;
+    z-index: 5;
+
+    $msg-offset: -27px;
+
+    // Define the success message properties
+    &::before,
+    &::after {
+      position: absolute;
+      top: $msg-offset;
+      z-index: 4;
+      opacity: 0;
+      transition: .1666s ease-in-out;
+      transition-property: opacity, transform;
+    }
+    &::before {
+      content: attr(data-message);
+      display: inline-block;
+      background: black;
+      color: white;
+      width: auto;
+      font-size: 14px;
+      padding: .2em .4em;
+      white-space: nowrap;
+      border-radius: 5px;
+      transform: translateX(-50%);
+    }
+    &::after {
+      content: '';
+      display: block;
+      width: 0;
+      height: 0;
+      border-left: 10px solid transparent;
+      border-right: 10px solid transparent;
+      border-top: 10px solid black;
+      top: $msg-offset + 19;
+    }
+  }
+
+  // Display the success message
+  .is--showing-success {
+    &::before {
+      opacity: 1;
+      transform: translateX(-50%) translateY(-10px);
+    }
+    &::after {
+      opacity: 1;
+      transform: translateY(-10px);
+    }
   }
 </style>

--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -3,7 +3,7 @@
     class="btn btn--link"
     :class="{'is--showing-success': showSuccessMessage}"
     :title="buttonText"
-    :data-message="'URL Copied!'"
+    :data-message="buttonSuccessMessage"
     :href="buttonHref"
     @click="copyUrlToClipboard">
     <span class="element-invisible">{{ buttonText }}</span>
@@ -54,6 +54,10 @@
         return (process.server)
           ? process.env.BASE_URL + cardPath
           : window.location.origin + cardPath;
+      },
+
+      buttonSuccessMessage() {
+        return this.$t('[THING] URL copied', this.locale).replace('[THING]', this.$t(this.label, this.locale));
       },
     },
 

--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -83,7 +83,7 @@
             }, 3000);
           })
           .catch(err => {
-            console.error(err);
+            console.error(err.message);
           });
       },
     }

--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -107,17 +107,26 @@
     position: relative;
     z-index: 5;
 
-    $msg-offset: -27px;
+    $msg-vertical-offset: -27px;
 
     // Define the success message properties
     &::before,
     &::after {
       position: absolute;
-      top: $msg-offset;
+      top: $msg-vertical-offset;
       z-index: 4;
       opacity: 0;
       transition: .1666s ease-in-out;
       transition-property: opacity, transform;
+
+      [dir="ltr"] & {
+        transform: translateX(-50%);
+        left: 15px;
+      }
+      [dir="rtl"] & {
+        transform: translateX(50%);
+        right: 15px;
+      }
     }
     &::before {
       content: attr(data-message);
@@ -129,13 +138,6 @@
       padding: .2em .4em;
       white-space: nowrap;
       border-radius: 5px;
-
-      [dir="ltr"] & {
-        transform: translateX(-50%);
-      }
-      [dir="rtl"] & {
-        transform: translateX(50%);
-      }
     }
     &::after {
       content: '';
@@ -145,13 +147,15 @@
       border-left: 10px solid transparent;
       border-right: 10px solid transparent;
       border-top: 10px solid black;
-      top: $msg-offset + 19;
+      top: $msg-vertical-offset + 19; // 19 = border-widths - 1 to ensure overlap
+      left: 50%;
     }
   }
 
   // Display the success message
   .is--showing-success {
-    &::before {
+    &::before,
+    &::after {
       opacity: 1;
 
       [dir="ltr"] & {
@@ -160,10 +164,6 @@
       [dir="rtl"] & {
         transform: translateX(50%) translateY(-10px);
       }
-    }
-    &::after {
-      opacity: 1;
-      transform: translateY(-10px);
     }
   }
 </style>

--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -129,7 +129,13 @@
       padding: .2em .4em;
       white-space: nowrap;
       border-radius: 5px;
-      transform: translateX(-50%);
+
+      [dir="ltr"] & {
+        transform: translateX(-50%);
+      }
+      [dir="rtl"] & {
+        transform: translateX(50%);
+      }
     }
     &::after {
       content: '';
@@ -147,7 +153,13 @@
   .is--showing-success {
     &::before {
       opacity: 1;
-      transform: translateX(-50%) translateY(-10px);
+
+      [dir="ltr"] & {
+        transform: translateX(-50%) translateY(-10px);
+      }
+      [dir="rtl"] & {
+        transform: translateX(50%) translateY(-10px);
+      }
     }
     &::after {
       opacity: 1;

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'انسخ [THING] URL إلى الحافظة',
+  '[THING] URL copied': '[THING] URL copied',
   'Save Situation Report as PDF': 'احفظ تقريرعن الوضع ك PDF',
   'Save [THING] as PNG': 'احفظ [THING] كملف PNG',
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Copy [THING] URL to clipboard',
+  '[THING] URL copied': '[THING] URL copied',
   'Save Situation Report as PDF': 'Save Situation Report as PDF',
   'Save [THING] as PNG': 'Save [THING] as PNG',
 

--- a/locales/es.js
+++ b/locales/es.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Copiar la URL [THING] en el portapapeles',
+  '[THING] URL copied': '[THING] URL copiado',
   'Save Situation Report as PDF': 'Guardar el informe de situación como PDF',
   'Save [THING] as PNG': 'Guardar [THING] como PNG',
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Copier l\'URL [THING] dans le presse-papier',
+  '[THING] URL copied': 'URL copié',
   'Save Situation Report as PDF': 'Sauvegarder le rapport de situation comme PDF',
   'Save [THING] as PNG': 'Sauvegarder [THING] comme PNG',
 

--- a/locales/rn.js
+++ b/locales/rn.js
@@ -103,6 +103,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Imura iyi [THING] URL mu kibanza',
+  '[THING] URL copied': '[THING] URL yimuwe',
   'Save Situation Report as PDF': 'Bika kino cegeranyo muri PDF',
   'Save [THING] as PNG': 'Bika ibintu [THING] nkisanamu(PNG)',
 

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Скопировать [THING] URL в буфер обмена',
+  '[THING] URL copied': '[THING] URL скопировано',
   'Save Situation Report as PDF': 'Сохранить Оперативную сводку в формате PDF',
   'Save [THING] as PNG': 'Сохранить [THING] в формате PNG',
 

--- a/locales/uk.js
+++ b/locales/uk.js
@@ -101,6 +101,7 @@ export default {
 
   // Card Actions
   'Copy [THING] URL to clipboard': 'Копіювати [THING] URL в буфер обміну',
+  '[THING] URL copied': '[THING] URL скопійовано',
   'Save Situation Report as PDF': 'Зберегти Оперативне зведення у форматі PDF',
   'Save [THING] as PNG': 'Зберегти [THING] у форматі PNG',
 


### PR DESCRIPTION
## DSR-275

There was a need for some UI feedback when copying URLs. This PR adds a little notification that appears above the button once our clipboard library is successful. If the clipboard fails, it logs an error to console, but does not report failure in a visual way to the user.

While testing I noticed a regression that crept in so part of the original work. So this PR also brings all the CardActions buttons back in line with each other. I dropped the old margin-spacing (which implicitly used whitespace nodes to separate them) and went with Flexbox.

Tested in the following:

- Win 7 IE11
- Win 10 Edge 18
- macOS Chrome 78
- macOS Firefox 70
- iOS 11 Safari
- iOS 13 Safari, Chrome
- Samsung Galaxy S8 Android 7 Chrome
- Nexus 5X Android 8 Chrome, Firefox