### PR TITLE
DSR-295: kirundi fallback for JS deps

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -12,7 +12,7 @@
         <span class="subtitle" v-if="subtitle">{{ subtitle }}</span>
         <span class="subtitle" v-else aria-hidden="true">&nbsp;</span>
 
-        <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(locale).format('D MMM YYYY') }}</time></span>
+        <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(localeOrFallback).format('D MMM YYYY') }}</time></span>
         <span class="past-sitreps" v-if="countrycode || customArchive"><a :href="archiveLink" target="_blank" rel="noopener">({{ $t('Archive', locale) }})</a></span>
       </div>
     </div>
@@ -41,7 +41,7 @@
           output="pdf"
           :title="title"
           :subtitle="subtitle"
-          :description="$t('Last updated', locale) + ': ' + $moment(updated).locale(locale).format('D MMM YYYY')"
+          :description="$t('Last updated', locale) + ': ' + $moment(updated).locale(localeOrFallback).format('D MMM YYYY')"
         />
         <div v-if="share" class="share" :class="{ 'share--is-open': shareIsOpen }">
           <no-ssr>
@@ -145,7 +145,7 @@
       },
 
       today() {
-        return this.$moment(Date.now()).locale(this.locale).format('D MMM YYYY');
+        return this.$moment(Date.now()).locale(this.localeOrFallback).format('D MMM YYYY');
       },
 
       archiveLink() {

--- a/components/CardFooter.vue
+++ b/components/CardFooter.vue
@@ -34,7 +34,7 @@
 
       // Format and localize date for humans.
       todayFormatted() {
-        return this.$moment(this.now).locale(this.locale).format('D MMM YYYY');
+        return this.$moment(this.now).locale(this.localeOrFallback).format('D MMM YYYY');
       },
 
       // This never needs to run on the server, so just print empty when no window.

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -91,7 +91,7 @@
       :show-pdf="showPdf"
       :title="$store.state.reportMeta.title"
       :subtitle="content.fields.title"
-      :description="$t('Last updated', locale) + ': ' + $moment(content.sys.updatedAt).locale(locale).format('D MMM YYYY')"
+      :description="$t('Last updated', locale) + ': ' + $moment(content.sys.updatedAt).locale(localeOrFallback).format('D MMM YYYY')"
       :filename-prefix="$t('Flash Update', locale)"
       :pdf-url="pdfUrl"
     />

--- a/components/KeyFinancials.vue
+++ b/components/KeyFinancials.vue
@@ -129,7 +129,7 @@
       ftsDataYear() {
         const plan = this.ftsRawData && this.ftsRawData.filter(plan => plan.id === this.ftsPlanId)[0] || false;
 
-        return plan && this.$moment.utc(plan.startDate).locale(this.locale).format('YYYY');
+        return plan && this.$moment.utc(plan.startDate).locale(this.localeOrFallback).format('YYYY');
       },
     },
 

--- a/components/SnapCard.vue
+++ b/components/SnapCard.vue
@@ -52,7 +52,7 @@
       },
 
       filename() {
-        const rightNow = this.$moment(Date.now()).locale(this.locale).format('D MMM YYYY');
+        const rightNow = this.$moment(Date.now()).locale(this.localeOrFallback).format('D MMM YYYY');
         return `${this.$t('Situation Report', this.locale)} - ${this.$store.state.reportMeta.title} - ${rightNow}.${this.output}`;
       },
     },

--- a/components/SnapPage.vue
+++ b/components/SnapPage.vue
@@ -64,7 +64,7 @@
       },
 
       filename() {
-        const dateUpdated = this.$moment(this.$store.state.reportMeta.dateUpdated).locale(this.locale).format('D MMM YYYY');
+        const dateUpdated = this.$moment(this.$store.state.reportMeta.dateUpdated).locale(this.localeOrFallback).format('D MMM YYYY');
         return `${this.$t(this.filenamePrefix, this.locale)} - ${this.$store.state.reportMeta.title} - ${dateUpdated}.${this.output}`;
       },
 
@@ -160,7 +160,7 @@
   </div>
   <div class="pdf-footer__right">
     <span class="url" dir="ltr"></span><br>
-    ${this.$t('Downloaded', this.locale)}: <span>${this.$moment().locale(this.locale).format('D MMM YYYY')}</span><br>
+    ${this.$t('Downloaded', this.locale)}: <span>${this.$moment().locale(this.localeOrFallback).format('D MMM YYYY')}</span><br>
   </div>
 </footer>
 <style type="text/css">

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -19,6 +19,14 @@
         return this.$store.state.locale;
       },
 
+      // Some dependencies like moment.js don't support all local languages. We
+      // have hardcoded fallbacks defined in our store in order to pass a known
+      // available language when the active locale is not supported.
+      localeOrFallback() {
+        const fallback = this.locales.filter((lang) => lang.code === this.locale)[0].fallback;
+        return fallback;
+      },
+
       // How many minutes since the Entry was published?
       timeAgoInMinutes() {
         return this.$moment(this.updatedAt).diff(this.$moment(), 'minutes') / -1;

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -101,7 +101,7 @@
         }
 
         // Return timestamp string based on our boolean.
-        return shouldFormat ? this.formatTimeAgo : this.$moment(this.updatedAt).locale(this.locale).format('D MMM YYYY');
+        return shouldFormat ? this.formatTimeAgo : this.$moment(this.updatedAt).locale(this.localeOrFallback).format('D MMM YYYY');
       },
 
       //

--- a/locales/rn.js
+++ b/locales/rn.js
@@ -1,7 +1,7 @@
 export default {
   // System
   'lang': 'rn',
-  'lang-name': 'Kirundi',
+  'lang-name': 'Ikirundi',
 
   // Global
   'UN OCHA': 'UN OCHA',

--- a/locales/rn.js
+++ b/locales/rn.js
@@ -25,7 +25,7 @@ export default {
   'OCHA Services': 'Ibikorwa vy\'ibiro mpuzamakungu vya ONU OCHA',
 
   // AppHeader
-  'Last updated': 'Last updated',
+  'Last updated': 'Amakuru mashasha',
   'Subscribe': 'Iyandikishe',
   'Share': 'Sabikanya',
   'Email': 'Ubutumwa',

--- a/pages/_lang/index.vue
+++ b/pages/_lang/index.vue
@@ -19,7 +19,7 @@
             >{{ localeName(translation.fields.language) }}</nuxt-link>
             <span class="sitrep__last-updated">
               <span class="element-invisible">{{ $t('Last updated', locale) }}:</span>
-              <time :datetime="translation.fields.dateUpdated" :dir="languageDirection(locale)">{{ $moment(translation.fields.dateUpdated).locale(locale).format('D MMM YYYY') }}</time>
+              <time :datetime="translation.fields.dateUpdated" :dir="languageDirection(locale)">{{ $moment(translation.fields.dateUpdated).locale(localeOrFallback).format('D MMM YYYY') }}</time>
             </span>
           </p>
         </article>

--- a/store/index.js
+++ b/store/index.js
@@ -23,60 +23,74 @@ export const state = () => ({
   //
   locales: [
     //
-    // Official UN Translations
+    // Official UN Languages
     //
     {
       code: 'en',
       name: 'English',
       dir: 'ltr',
       display: true,
+      fallback: 'en',
     },
     {
       code: 'es',
       name: 'Español',
       dir: 'ltr',
       display: true,
+      fallback: 'es',
     },
     {
       code: 'fr',
       name: 'Français',
       dir: 'ltr',
       display: true,
+      fallback: 'fr',
     },
     {
       code: 'ru',
       name: 'Русский',
       dir: 'ltr',
       display: true,
+      fallback: 'ru',
     },
     {
       code: 'ar',
       name: 'عربي',
       dir: 'rtl',
       display: true,
+      fallback: 'ar',
     },
     // {
     //   code: 'zh',
     //   name: '中文',
     //   dir: 'ltr', // Following www.un.org/zh/ for direction
     //   display: true,
+    //   fallback: 'zh',
     // },
 
     //
-    // Non-default languages.
-    // All languages below this comment should have `display: false`
+    // Local languages
+    //
+    // * All languages below this comment MUST have `display: false`
+    //
+    // * The `fallback` MUST be one of the active UN-official languages in the
+    //   block defined above these Local Languages. Some of our dependencies
+    //   don't support all of our local languages and each region should decide
+    //   what language they prefer as their fallback.
     //
     {
       code: 'rn',
       name: 'Kirundi',
       dir: 'ltr',
       display: false,
+      fallback: 'en',
     },
     {
       code: 'uk',
       name: 'Українська',
       dir: 'ltr',
       display: false,
+      fallback: 'ru',
     },
   ],
 

--- a/store/index.js
+++ b/store/index.js
@@ -80,7 +80,7 @@ export const state = () => ({
     //
     {
       code: 'rn',
-      name: 'Kirundi',
+      name: 'Ikirundi',
       dir: 'ltr',
       display: false,
       fallback: 'en',


### PR DESCRIPTION
## DSR-295

We noticed that moment.js doesn't have support for Kirundi (or a couple other local languages which are on the docket). Long-term we'd love to provide the locales upstream, but in the mean time we've added a `fallback` property to each locale definition so that the official UN-6 language of choice can be substituted when necessary.