### PR TITLE
DSR-306: fix layout bug caused by CardUrl feedback element

### DIFF
--- a/components/CardUrl.vue
+++ b/components/CardUrl.vue
@@ -120,11 +120,11 @@
       transition-property: opacity, transform;
 
       [dir="ltr"] & {
-        transform: translateX(-50%);
+        transform: translateX(-80%);
         left: 15px;
       }
       [dir="rtl"] & {
-        transform: translateX(50%);
+        transform: translateX(80%);
         right: 15px;
       }
     }
@@ -148,7 +148,13 @@
       border-right: 10px solid transparent;
       border-top: 10px solid black;
       top: $msg-vertical-offset + 19; // 19 = border-widths - 1 to ensure overlap
-      left: 50%;
+
+      [dir="ltr"] & {
+        transform: translateX(-50%);
+      }
+      [dir="rtl"] & {
+        transform: translateX(50%);
+      }
     }
   }
 
@@ -157,7 +163,18 @@
     &::before,
     &::after {
       opacity: 1;
+    }
 
+    &::before {
+      [dir="ltr"] & {
+        transform: translateX(-80%) translateY(-10px);
+      }
+      [dir="rtl"] & {
+        transform: translateX(80%) translateY(-10px);
+      }
+    }
+
+    &::after {
       [dir="ltr"] & {
         transform: translateX(-50%) translateY(-10px);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## DSR-306

During my final cross-browser testing on dev, I noticed on mobile the layout was getting pushed to the side. Initially thinking it an RTL bug, but it turned out to affect pretty much any language on mobile. Desktop wasn't affected.

When copying a CardUrl, the message length can vary since it populates the Card type into the message (e.g. Feature, Visuals and Data, Emergency Response) — the variable length of these messages combined with translations can result in an unpredictable placement. By repositioning the message to not be exactly centered over the button, we can avoid any layout issues on mobile.