### PR TITLE
DSR-307: add fb:app_id meta tag + E2E

### DIFF
--- a/_tests/Card.test.js
+++ b/_tests/Card.test.js
@@ -1,9 +1,10 @@
 const env = {
   baseUrl: 'https://reports.unocha.org',
+  fbAppId: '1916193535375038',
 };
 
 describe('Valid Cards', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await page.goto(`${env.baseUrl}/fr/country/burundi/`);
   });
 
@@ -67,6 +68,16 @@ describe('Valid Cards', () => {
 
       expect(ogImage).toMatch('images.ctfassets.net');
       expect(ogImage).toBe(twImage);
+    });
+  });
+
+  it('should output correct fb:app_id meta tag', async () => {
+    await page.waitForSelector('.btn--card-url').then(async () => {
+      const expectedUrl = await page.$eval('.btn--card-url', el => el.href);
+      const response = await page.goto(expectedUrl);
+      const fbAppId = await page.$eval('meta[property="fb:app_id"]', el => el.getAttribute('content'));
+
+      expect(fbAppId).toMatch(env.fbAppId);
     });
   });
 });

--- a/_tests/SitRep.test.js
+++ b/_tests/SitRep.test.js
@@ -1,5 +1,6 @@
 const env = {
   baseUrl: 'https://reports.unocha.org',
+  fbAppId: '1916193535375038',
 };
 
 import fr from '../locales/fr.js';
@@ -17,9 +18,9 @@ describe('SitRep JS Disabled', () => {
   });
 
   it('should load CardUrl link', async () => {
-    const expectedLength = 0;
-    const actualLength = await page.$$eval('.btn--card-url', nodeList => nodeList.length);
-    await expect(actualLength).toBeGreaterThan(expectedLength);
+    const minimumCardUrls = 0;
+    const actualCardUrls = await page.$$eval('.btn--card-url', nodeList => nodeList.length);
+    await expect(actualCardUrls).toBeGreaterThan(minimumCardUrls);
   });
 
   it('should load HTML content', async () => {
@@ -30,6 +31,17 @@ describe('SitRep JS Disabled', () => {
     });
   });
 
+  it('should output correct fb:app_id meta tag', async () => {
+    await page.waitForSelector('.btn--card-url').then(async () => {
+      const expectedUrl = await page.$eval('.btn--card-url', el => el.href);
+      const response = await page.goto(expectedUrl);
+      const fbAppId = await page.$eval('meta[property="fb:app_id"]', el => el.getAttribute('content'));
+
+      expect(fbAppId).toMatch(env.fbAppId);
+    });
+  });
+
+  // ⚠️ This needs to be the last test since it navigates to Homepage.
   it('should link to localized Homepage based on SitRep language', async () => {
     await Promise.all([
       page.waitForNavigation(),

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -29,6 +29,7 @@ module.exports = {
     CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
     CTF_CDA_PREVIEW_TOKEN: process.env.CTF_CDA_PREVIEW_TOKEN,
     baseUrl: process.env.BASE_URL,
+    fbAppId: '1916193535375038',
   },
   //
   // Global <head> metadata

--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -229,6 +229,7 @@
           { hid: 'tw-image', name: 'twitter:image', content: this.socialImageUrl },
           { hid: 'tw-site', name: 'twitter:site', content: '@UNOCHA' },
           { hid: 'tw-creator', name: 'twitter:creator', content: this.twitterCreator },
+          { hid: 'fb-app-id', property: 'fb:app_id', content: process.env.fbAppId },
           { hid: 'og-type', property: 'og:type', content: 'website' },
           { hid: 'og-url', property: 'og:url', content: `${baseUrl}/${this.parents[0].fields.language}/country/${this.parents[0].fields.slug}/card/${this.sysIdShort}/` },
           { hid: 'og-title', property: 'og:title', content: this.officeName },

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -177,6 +177,7 @@
           { hid: 'tw-title', name: 'twitter:title', content: this.$t('Situation Report', this.locale) + ': ' + this.entry.fields.title },
           { hid: 'tw-site', name: 'twitter:site', content: '@UNOCHA' },
           { hid: 'tw-creator', name: 'twitter:creator', content: '@UNOCHA' },
+          { hid: 'fb-app-id', property: 'fb:app_id', content: process.env.fbAppId },
           { hid: 'og-type', property: 'og:type', content: 'website' },
           { hid: 'og-url', property: 'og:url', content: `https://reports.unocha.org/${this.entry.fields.language}/country/${this.entry.fields.slug}/` },
           { hid: 'og-title', property: 'og:title', content: this.entry.fields.title },


### PR DESCRIPTION
## DSR-307

Our FB validator complained about the missing App ID. We're re-using the RW ID per Miguel's direction.