### PR TITLE
DSR-297: Twitter/OG image meta tags improved

### DIFF
--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -61,10 +61,47 @@
         return this.entry.sys.id.slice(0, 10);
       },
 
+      hasOwnImage() {
+        return this.entry.fields.image && this.entry.fields.image.fields && this.entry.fields.image.fields.file && this.entry.fields.image.fields.file.url || false;
+      },
+
       socialImageUrl() {
-        return (this.entry.fields.image && this.entry.fields.image.fields && this.entry.fields.image.fields.file && this.entry.fields.image.fields.file.url)
-          ? 'https:' + this.entry.fields.image.fields.file.url + '?w=1024'
-          : 'https:' + this.parents[0].fields.keyMessagesImage.fields.file.url + '?w=1024'
+        return (this.hasOwnImage)
+          ? 'https:' + this.entry.fields.image.fields.file.url + '?w=' + this.socialImageWidth
+          : 'https:' + this.parents[0].fields.keyMessagesImage.fields.file.url + '?w=' + this.socialImageWidth
+      },
+
+      socialImageType() {
+        return (this.hasOwnImage)
+          ? this.entry.fields.image.fields.file.contentType
+          : this.parents[0].fields.keyMessagesImage.fields.file.contentType;
+      },
+
+      socialImageAlt() {
+        return (this.hasOwnImage)
+          ? this.entry.fields.image.fields.title
+          : this.parents[0].fields.keyMessagesImage.fields.title;
+      },
+
+      socialImageWidth() {
+        const actualWidth = (this.hasOwnImage)
+          ? this.entry.fields.image.fields.file.details.image.width
+          : this.parents[0].fields.keyMessagesImage.fields.file.details.image.width;
+
+        return (actualWidth > 1024) ? '1024' : actualWidth;
+      },
+
+      socialImageHeight() {
+        const actualWidth = (this.hasOwnImage)
+          ? this.entry.fields.image.fields.file.details.image.width
+          : this.parents[0].fields.keyMessagesImage.fields.file.details.image.width;
+
+        const actualHeight = (this.hasOwnImage)
+          ? this.entry.fields.image.fields.file.details.image.height
+          : this.parents[0].fields.keyMessagesImage.fields.file.details.image.height;
+
+        // Do this based on how much we scaled the WIDTH down.
+        return (actualWidth > 1024) ? Math.floor(1024 / actualWidth * actualHeight) : actualHeight;
       },
 
       officeName() {
@@ -225,6 +262,7 @@
           { hid: 'tw-title', name: 'twitter:title', content: this.officeName },
           { hid: 'tw-desc', name: 'twitter:description', content: this.headerSubtitle },
           { hid: 'tw-image', name: 'twitter:image', content: this.socialImageUrl },
+          { hid: 'tw-image-alt', name: 'twitter:image:alt', content: this.socialImageAlt },
           { hid: 'tw-site', name: 'twitter:site', content: '@UNOCHA' },
           { hid: 'tw-creator', name: 'twitter:creator', content: this.twitterCreator },
           { hid: 'fb-app-id', property: 'fb:app_id', content: process.env.fbAppId },
@@ -234,6 +272,9 @@
           { hid: 'og-title', property: 'og:title', content: this.officeName },
           { hid: 'og-desc', property: 'og:description', content: this.headerSubtitle },
           { hid: 'og-image', property: 'og:image', content: this.socialImageUrl },
+          { hid: 'og-image-type', property: 'og:image:type', content: this.socialImageType },
+          { hid: 'og-image-width', property: 'og:image:width', content: this.socialImageWidth },
+          { hid: 'og-image-height', property: 'og:image:height', content: this.socialImageHeight },
         ],
       };
     },

--- a/pages/_lang/country/_slug/index.vue
+++ b/pages/_lang/country/_slug/index.vue
@@ -177,6 +177,8 @@
           { hid: 'tw-title', name: 'twitter:title', content: this.$t('Situation Report', this.locale) + ': ' + this.entry.fields.title },
           { hid: 'tw-site', name: 'twitter:site', content: '@UNOCHA' },
           { hid: 'tw-creator', name: 'twitter:creator', content: '@UNOCHA' },
+          { hid: 'tw-image', name: 'twitter:image', content: (this.keyMessagesHasImage) ? 'https:' + this.entry.fields.keyMessagesImage.fields.file.url : '' },
+          { hid: 'tw-image-alt', name: 'twitter:image:alt', content: (this.keyMessagesHasImage) ? this.entry.fields.keyMessagesImage.fields.title : '' },
           { hid: 'fb-app-id', property: 'fb:app_id', content: process.env.fbAppId },
           { hid: 'og-type', property: 'og:type', content: 'article' },
           { hid: 'og-locale', property: 'og:locale', content: this.entry.fields.language },
@@ -184,6 +186,9 @@
           { hid: 'og-title', property: 'og:title', content: this.entry.fields.title },
           { hid: 'og-desc', property: 'og:description', content: this.keyMessagesJoined },
           { hid: 'og-image', property: 'og:image', content: (this.keyMessagesHasImage) ? 'https:' + this.entry.fields.keyMessagesImage.fields.file.url : '' },
+          { hid: 'og-image-type', property: 'og:image:type', content: (this.keyMessagesHasImage) ? this.entry.fields.keyMessagesImage.fields.file.contentType : '' },
+          { hid: 'og-image-width', property: 'og:image:width', content: (this.keyMessagesHasImage) ? this.entry.fields.keyMessagesImage.fields.file.details.image.width : '' },
+          { hid: 'og-image-height', property: 'og:image:height', content: (this.keyMessagesHasImage) ? this.entry.fields.keyMessagesImage.fields.file.details.image.height : '' },
         ],
       };
     },


### PR DESCRIPTION
## DSR-297

* `twitter:image:alt`
* `og:image:width`
* `og:image:height`
* `og:image:type`

Images get scaled down to 1024-wide when they exceed the threshold.