### PR TITLE
DSR-308: apply SitRep footer customizations to standalone Cards

### DIFF
--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -18,7 +18,7 @@
       <component :is="componentMap[entry.sys.contentType.sys.id]" :content="entry" :force-expanded="true" v-if="typeof entry !== 'undefined' && typeof entry.fields !== 'undefined'" />
     </main>
 
-    <AppFooter />
+    <AppFooter :footer="parents[0].fields.footer" />
   </div>
 </template>
 


### PR DESCRIPTION
## DSR-308

A really quick win to further customize standalone Card URLs. Whatever Footer customizations are applied to a SitRep, we display those on the Card footers as well now. This includes:

* Custom footer text
* Up to 3x links (typically pointing to unocha.org, HR.info, and reliefweb)
* FB/Twitter accounts for the Office.

Behavior is unchanged if the footer is not customized. We have defaults in place for all languages.