### PR TITLE
DSR-304: guard against missing language when looking up localeName

### DIFF
--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -196,7 +196,7 @@
       //
       localeName(langCode) {
         const targetLocale = this.locales.find((locale) => locale.code === langCode);
-        return targetLocale.name;
+        return targetLocale && targetLocale.name || `Language not installed: ${langCode}`;
       },
 
       //


### PR DESCRIPTION
## DSR-304

Step 1 for the issue was removing the errors I got while doing local development and switching between branches that don't have the same locale list.

However if we ever managed to add a language in the DB without supporting it in code, this will save us from a fatal error on the homepage.