### PR TITLE
DSR-309: standalone Cards with long titles

### DIFF
--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -297,7 +297,12 @@
 //
 // Snap PDFs
 //
-.snap--pdf .go-back {
-  display: none;
+.snap--pdf {
+  .go-back {
+    display: none;
+  }
+  .page--card .card {
+    border-bottom: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## DSR-309

PDFs of standalone Cards with long titles were looking a bit shaggy. This fixes it up. It may seem like a weird solution, but the Puppeteer PDF Headers are themselves weird and they make us do weird things to work with them. Such is life.

While I was testing I noticed the Cards have an unnecessary `border-bottom` on the PDF. Gone.