### PR TITLE
DSR-312: create factory for SitRep-specific feeds

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -93,8 +93,12 @@ module.exports = {
   //
   // RSS Feeds
   //
-  feed: [
-    {
+  feed: async () => {
+    // We'll collect all the feeds here and return at the very end.
+    const feeds = [];
+
+    // RSS: all SitReps
+    feeds.push({
       path: '/feeds/sitreps.xml',
       async create(feed) {
         //
@@ -152,8 +156,10 @@ module.exports = {
       cacheTime: 1000,// * 60 * 60 * 24,
       type: 'rss2',
       data: [],
-    },
-    {
+    });
+
+    // RSS: all Flash Updates
+    feeds.push({
       path: '/feeds/flashupdates.xml',
       async create(feed) {
         const renderer = require('@contentful/rich-text-html-renderer');
@@ -216,354 +222,194 @@ module.exports = {
       cacheTime: 1000,// * 60 * 60 * 24,
       type: 'rss2',
       data: [],
-    },
-    {
-      path: '/feeds/en/country/afghanistan.xml',
-      async create(feed) {
-        // Render CTF rich text
-        const renderer = require('@contentful/rich-text-html-renderer');
-        const richText = renderer.documentToHtmlString;
+    });
 
-        // Define which country/office we're pulling data from
-        const THIS_LANG = 'en';
-        const THIS_SLUG = 'afghanistan';
+    // Query CTF for sitrep/lang combos. We'll map through these and return one
+    // feed per item returned.
+    const allSitreps = await client.getEntries({
+      include: 0,
+      content_type: 'sitrep',
+      select: 'sys.id,fields.title,fields.dateUpdated,fields.slug,fields.language',
+    });
 
-        //
-        // Query Contentful for:
-        //
-        // * All content within the sitrep specified above.
-        //
-        // NOTE: do NOT edit the feed below. It is basically a template and
-        // should behave like all the others. If you want to add a new one, copy
-        // and paste this feed definition, change the THIS_LANG/THIS_SLUG, and
-        // add it to the top-level feed array.
-        //
-        const sitreps = await client.getEntries({
-          'include': 10,
-          'content_type': 'sitrep',
-          'fields.language': THIS_LANG,
-          'fields.slug': THIS_SLUG,
-          'order': '-sys.updatedAt',
-          'limit': 1,
-        })
-        .catch(console.error);
+    // Capture each sitrep feed into an array which we'll spread and push later.
+    const eachSitrepFeed = allSitreps.items.map(entry => {
+      return {
+        path: `/feeds/${entry.fields.language}/country/${entry.fields.slug}.xml`,
+        async create(feed) {
+          // Render CTF rich text
+          const renderer = require('@contentful/rich-text-html-renderer');
+          const richText = renderer.documentToHtmlString;
 
-        // Query returns one entry. Put it in a new var.
-        const sitrep = sitreps.items[0];
+          // Define which country/office we're pulling data from
+          const THIS_LANG = entry.fields.language;
+          const THIS_SLUG = entry.fields.slug;
 
-        // Ultimately, the RSS feed should output everything in the order it is
-        // published, rather than grouping it according to how it would appear
-        // on an actual SitRep.
-        //
-        // To that end, we will stub an array and sort it before finally adding
-        // each <item> to the feed.
-        const feedItems = [];
+          //
+          // Query Contentful for:
+          //
+          // * All content within the sitrep specified above.
+          //
+          const sitreps = await client.getEntries({
+            'include': 10,
+            'content_type': 'sitrep',
+            'fields.language': THIS_LANG,
+            'fields.slug': THIS_SLUG,
+            'order': '-sys.updatedAt',
+            'limit': 1,
+          })
+          .catch(console.error);
 
-        // Highlights
-        sitrep.fields
-          && sitrep.fields.keyMessages
-          && sitrep.fields.keyMessages
-            .filter(msg => typeof msg.fields !== 'undefined')
-            .forEach(msg => {
-              msg.fields && msg.fields.keyMessage && feedItems.push({
-                title: msg.fields.keyMessage,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                date: new Date(Date.parse(msg.sys.updatedAt)),
-              })
+          // Query returns one entry. Put it in a new var.
+          const sitrep = sitreps.items[0];
+
+          // Ultimately, the RSS feed should output everything in the order it is
+          // published, rather than grouping it according to how it would appear
+          // on an actual SitRep.
+          //
+          // To that end, we will stub an array and sort it before finally adding
+          // each <item> to the feed.
+          const feedItems = [];
+
+          // Highlights
+          sitrep.fields
+            && sitrep.fields.keyMessages
+            && sitrep.fields.keyMessages
+              .filter(msg => typeof msg.fields !== 'undefined')
+              .forEach(msg => {
+                msg.fields && msg.fields.keyMessage && feedItems.push({
+                  title: msg.fields.keyMessage,
+                  id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
+                  link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
+                  date: new Date(Date.parse(msg.sys.updatedAt)),
+                })
+              });
+
+          // Key Figures
+          sitrep.fields
+            && sitrep.fields.keyFigure
+            && sitrep.fields.keyFigure
+              .filter(figure => typeof figure.fields !== 'undefined')
+              .forEach(figure => {
+                figure.fields && figure.fields.figure && feedItems.push({
+                  title: `${figure.fields.figure} ${figure.fields.caption}`,
+                  id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
+                  link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
+                  date: new Date(Date.parse(figure.sys.updatedAt)),
+                  description: figure.fields.source ? `Source: ${figure.fields.source}` : false,
+                })
+              });
+
+          // Content stream (Articles, Clusters, Interactives, Visuals, Videos)
+          sitrep.fields
+            && sitrep.fields.article
+            && sitrep.fields.article
+              .filter(card => typeof card.fields !== 'undefined')
+              .forEach(card => {
+                const cardType = card.sys.contentType.sys.id;
+                let cardDescription = '';
+                let cardTitle = '';
+
+                //
+                // Populate based on Card type
+                //
+                if (cardType === 'article') {
+                  cardTitle = card.fields.title ? `${card.fields.sectionHeading}: ${card.fields.title}` : 'Untitled Article';
+                  cardDescription = (card.fields.body ? richText(card.fields.body, {}) : '')
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+                }
+                if (cardType === 'clusterInformation') {
+                  cardTitle = `${card.fields.sectionHeading || 'Cluster'} Status: ${card.fields.clusterName}`;
+                  cardDescription = ('<h3>Needs</h3>' + richText(card.fields.clusterNeeds, {}) +'<h3>Response</h3>'+ richText(card.fields.clusterResponse, {}) +'<h3>Gaps</h3>'+ richText(card.fields.clusterGaps, {}))
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;")
+                }
+                if (cardType === 'interactive') {
+                  cardTitle = card.fields.title || 'Untitled Interactive';
+                  cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+                }
+                if (cardType === 'visual') {
+                  cardTitle = card.fields.title || 'Untitled Visual';
+                  cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+                }
+                if (cardType === 'video') {
+                  cardTitle = `Video: ${card.fields.videoUrl}`;
+                  cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+                }
+
+                cardTitle && feedItems.push({
+                  title: cardTitle,
+                  id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
+                  link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
+                  date: new Date(Date.parse(card.sys.updatedAt)),
+                  description: cardDescription,
+                })
+              });
+
+
+          // Sort by newest date, then push into feed.
+          feedItems.sort((a, b) => {
+            return b.date - a.date;
+          }).forEach(item => {
+            feed.addItem({
+              title: item.title,
+              id: item.id,
+              link: item.link,
+              date: item.date,
+              description: item.description || false,
             });
-
-        // Key Figures
-        sitrep.fields
-          && sitrep.fields.keyFigure
-          && sitrep.fields.keyFigure
-            .filter(figure => typeof figure.fields !== 'undefined')
-            .forEach(figure => {
-              figure.fields && figure.fields.figure && feedItems.push({
-                title: `${figure.fields.figure} ${figure.fields.caption}`,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                date: new Date(Date.parse(figure.sys.updatedAt)),
-                description: figure.fields.source ? `Source: ${figure.fields.source}` : false,
-              })
-            });
-
-        // Content stream (Articles, Clusters, Interactives, Visuals, Videos)
-        sitrep.fields
-          && sitrep.fields.article
-          && sitrep.fields.article
-            .filter(card => typeof card.fields !== 'undefined')
-            .forEach(card => {
-              const cardType = card.sys.contentType.sys.id;
-              let cardDescription = '';
-              let cardTitle = '';
-
-              //
-              // Populate based on Card type
-              //
-              if (cardType === 'article') {
-                cardTitle = card.fields.title ? `${card.fields.sectionHeading}: ${card.fields.title}` : 'Untitled Article';
-                cardDescription = (card.fields.body ? richText(card.fields.body, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'clusterInformation') {
-                cardTitle = `${card.fields.sectionHeading || 'Cluster'} Status: ${card.fields.clusterName}`;
-                cardDescription = ('<h3>Needs</h3>' + richText(card.fields.clusterNeeds, {}) +'<h3>Response</h3>'+ richText(card.fields.clusterResponse, {}) +'<h3>Gaps</h3>'+ richText(card.fields.clusterGaps, {}))
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;")
-              }
-              if (cardType === 'interactive') {
-                cardTitle = card.fields.title || 'Untitled Interactive';
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'visual') {
-                cardTitle = card.fields.title || 'Untitled Visual';
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'video') {
-                cardTitle = `Video: ${card.fields.videoUrl}`;
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-
-              cardTitle && feedItems.push({
-                title: cardTitle,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
-                date: new Date(Date.parse(card.sys.updatedAt)),
-                description: cardDescription,
-              })
-            });
-
-
-        // Sort by newest date, then push into feed.
-        feedItems.sort((a, b) => {
-          return b.date - a.date;
-        }).forEach(item => {
-          feed.addItem({
-            title: item.title,
-            id: item.id,
-            link: item.link,
-            date: item.date,
-            description: item.description || false,
           });
-        });
 
-        feed.options = {
-          title: `${sitrep.fields.title} - ${THIS_LANG.toUpperCase()}`,
-          link: `${process.env.BASE_URL}/feeds/${THIS_LANG}/country/${THIS_SLUG}.xml`,
-          description: `All content for ${sitrep.fields.title} published on ${process.env.BASE_URL}`,
-          docs: 'https://validator.w3.org/feed/docs/rss2.html',
-          // Measured in MINUTES. See `docs` link.
-          ttl: 60 * 24,
-          date: new Date(Date.now()),
-        }
+          feed.options = {
+            title: `${sitrep.fields.title} - ${THIS_LANG.toUpperCase()}`,
+            link: `${process.env.BASE_URL}/feeds/${THIS_LANG}/country/${THIS_SLUG}.xml`,
+            description: `All content for ${sitrep.fields.title} published on ${process.env.BASE_URL}`,
+            docs: 'https://validator.w3.org/feed/docs/rss2.html',
+            // Measured in MINUTES. See `docs` link.
+            ttl: 60 * 24,
+            date: new Date(Date.now()),
+          }
 
-        feed.addContributor({
-          name: 'UN OCHA',
-          link: 'https://www.unocha.org',
-        });
-      },
-      // Measured in milliseconds.
-      cacheTime: 1000,// * 60 * 60 * 24,
-      type: 'rss2',
-      data: [],
-    },
-    {
-      path: '/feeds/fr/country/burundi.xml',
-      async create(feed) {
-        // Render CTF rich text
-        const renderer = require('@contentful/rich-text-html-renderer');
-        const richText = renderer.documentToHtmlString;
-
-        // Define which country/office we're pulling data from
-        const THIS_LANG = 'fr';
-        const THIS_SLUG = 'burundi';
-
-        //
-        // Query Contentful for:
-        //
-        // * All content within the sitrep specified above.
-        //
-        // NOTE: do NOT edit the feed below. It is basically a template and
-        // should behave like all the others. If you want to add a new one, copy
-        // and paste this feed definition, change the THIS_LANG/THIS_SLUG, and
-        // add it to the top-level feed array.
-        //
-        const sitreps = await client.getEntries({
-          'include': 10,
-          'content_type': 'sitrep',
-          'fields.language': THIS_LANG,
-          'fields.slug': THIS_SLUG,
-          'order': '-sys.updatedAt',
-          'limit': 1,
-        })
-        .catch(console.error);
-
-        // Query returns one entry. Put it in a new var.
-        const sitrep = sitreps.items[0];
-
-        // Ultimately, the RSS feed should output everything in the order it is
-        // published, rather than grouping it according to how it would appear
-        // on an actual SitRep.
-        //
-        // To that end, we will stub an array and sort it before finally adding
-        // each <item> to the feed.
-        const feedItems = [];
-
-        // Highlights
-        sitrep.fields
-          && sitrep.fields.keyMessages
-          && sitrep.fields.keyMessages
-            .filter(msg => typeof msg.fields !== 'undefined')
-            .forEach(msg => {
-              msg.fields && msg.fields.keyMessage && feedItems.push({
-                title: msg.fields.keyMessage,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                date: new Date(Date.parse(msg.sys.updatedAt)),
-              })
-            });
-
-        // Key Figures
-        sitrep.fields
-          && sitrep.fields.keyFigure
-          && sitrep.fields.keyFigure
-            .filter(figure => typeof figure.fields !== 'undefined')
-            .forEach(figure => {
-              figure.fields && figure.fields.figure && feedItems.push({
-                title: `${figure.fields.figure} ${figure.fields.caption}`,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/`,
-                date: new Date(Date.parse(figure.sys.updatedAt)),
-                description: figure.fields.source ? `Source: ${figure.fields.source}` : false,
-              })
-            });
-
-        // Content stream (Articles, Clusters, Interactives, Visuals, Videos)
-        sitrep.fields
-          && sitrep.fields.article
-          && sitrep.fields.article
-            .filter(card => typeof card.fields !== 'undefined')
-            .forEach(card => {
-              const cardType = card.sys.contentType.sys.id;
-              let cardDescription = '';
-              let cardTitle = '';
-
-              //
-              // Populate based on Card type
-              //
-              if (cardType === 'article') {
-                cardTitle = card.fields.title ? `${card.fields.sectionHeading}: ${card.fields.title}` : 'Untitled Article';
-                cardDescription = (card.fields.body ? richText(card.fields.body, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'clusterInformation') {
-                cardTitle = `${card.fields.sectionHeading || 'Cluster'} Status: ${card.fields.clusterName}`;
-                cardDescription = ('<h3>Needs</h3>' + richText(card.fields.clusterNeeds, {}) +'<h3>Response</h3>'+ richText(card.fields.clusterResponse, {}) +'<h3>Gaps</h3>'+ richText(card.fields.clusterGaps, {}))
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;")
-              }
-              if (cardType === 'interactive') {
-                cardTitle = card.fields.title || 'Untitled Interactive';
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'visual') {
-                cardTitle = card.fields.title || 'Untitled Visual';
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-              if (cardType === 'video') {
-                cardTitle = `Video: ${card.fields.videoUrl}`;
-                cardDescription = (card.fields.description ? richText(card.fields.description, {}) : '')
-                  .replace(/&/g, "&amp;")
-                  .replace(/</g, "&lt;")
-                  .replace(/>/g, "&gt;")
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&#039;");
-              }
-
-              cardTitle && feedItems.push({
-                title: cardTitle,
-                id: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
-                link: `${process.env.BASE_URL}/${THIS_LANG}/country/${THIS_SLUG}/card/${card.sys.id.slice(0, 10)}/`,
-                date: new Date(Date.parse(card.sys.updatedAt)),
-                description: cardDescription,
-              })
-            });
-
-
-        // Sort by newest date, then push into feed.
-        feedItems.sort((a, b) => {
-          return b.date - a.date;
-        }).forEach(item => {
-          feed.addItem({
-            title: item.title,
-            id: item.id,
-            link: item.link,
-            date: item.date,
-            description: item.description || false,
+          feed.addContributor({
+            name: 'UN OCHA',
+            link: 'https://www.unocha.org',
           });
-        });
+        },
+        // Measured in milliseconds.
+        cacheTime: 1000,// * 60 * 60 * 24,
+        type: 'rss2',
+        data: [],
+      };
+    });
 
-        feed.options = {
-          title: `${sitrep.fields.title} - ${THIS_LANG.toUpperCase()}`,
-          link: `${process.env.BASE_URL}/feeds/${THIS_LANG}/country/${THIS_SLUG}.xml`,
-          description: `All content for ${sitrep.fields.title} published on ${process.env.BASE_URL}`,
-          docs: 'https://validator.w3.org/feed/docs/rss2.html',
-          // Measured in MINUTES. See `docs` link.
-          ttl: 60 * 24,
-          date: new Date(Date.now()),
-        }
+    // Spread the sitrep array and add to our factory array.
+    feeds.push(...eachSitrepFeed);
 
-        feed.addContributor({
-          name: 'UN OCHA',
-          link: 'https://www.unocha.org',
-        });
-      },
-      // Measured in milliseconds.
-      cacheTime: 1000,// * 60 * 60 * 24,
-      type: 'rss2',
-      data: [],
-    },
-  ],
+    // Send factory array to the generator
+    return feeds;
+  },
   //
   // Static Generation config
   //

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -234,16 +234,17 @@ module.exports = {
 
     // Capture each sitrep feed into an array which we'll spread and push later.
     const eachSitrepFeed = allSitreps.items.map(entry => {
+      // Define which country/office we're pulling data from
+      const THIS_LANG = entry.fields.language;
+      const THIS_SLUG = entry.fields.slug;
+
+      // Define this Sitrep's feed
       return {
-        path: `/feeds/${entry.fields.language}/country/${entry.fields.slug}.xml`,
+        path: `/feeds/${THIS_LANG}/country/${THIS_SLUG}.xml`,
         async create(feed) {
           // Render CTF rich text
           const renderer = require('@contentful/rich-text-html-renderer');
           const richText = renderer.documentToHtmlString;
-
-          // Define which country/office we're pulling data from
-          const THIS_LANG = entry.fields.language;
-          const THIS_SLUG = entry.fields.slug;
 
           //
           // Query Contentful for:


### PR DESCRIPTION
Instead of the gross duplication of logic to create individual sitreps, we now have a factory that is driven off of Contentful data. You can now find an equivalent feed for every SitRep URL that is published on the site:

- `/fr/country/burundi/` => `/feeds/fr/country/burundi.xml`
- `/so/country/somalia/` => `/feeds/so/country/somalia.xml`

...and so forth