### PR TITLE
DSR-209: remove our hack to call asyncData on page mount

### DIFF
--- a/pages/_lang/country/_slug/flash-update/_sysid.vue
+++ b/pages/_lang/country/_slug/flash-update/_sysid.vue
@@ -108,12 +108,6 @@
       }
     },
 
-    // In order to fetch data both during asyncData() and at other times of our
-    // own choosing, we have our own custom function which is defined outside
-    // our export.
-    // asyncData is an official API event of Nuxt. It's used to fetch data for
-    // both SSR and client-side navigations.
-
     asyncData({env, params, store, error, req, res}) {
       return Promise.all([
 


### PR DESCRIPTION
## DSR-209

The workaround was originally in place to freshen content beyond the 5-minute static generation cycle. Over a period of months we first switched to dynamic SSR and then lowered the cache lifetime
from 5 minutes to 1. So the reason to double-fetch data is all but removed nowadays.

Diff is kinda big but I just moved a function from one place to another, not much more.