### PR TITLE
DSR-289: social integration for Video cards

### DIFF
--- a/components/Video.vue
+++ b/components/Video.vue
@@ -80,8 +80,7 @@
       },
 
       videoSlug() {
-        const videoSlug = this.parseQueryParams('v');
-        return videoSlug;
+        return this.parseQueryParams(this.content.fields.videoUrl, 'v');
       },
 
       videoEmbedLink() {
@@ -103,28 +102,6 @@
         ev.preventDefault();
 
         this.videoProcessed = true;
-      },
-
-      // Parse URL parameters
-      //
-      // Since IE11+node don't support URLSearchParams
-      //
-      // @see https://stackoverflow.com/a/901144
-      // @see https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility
-      parseQueryParams(name) {
-        name = name.replace(/[\[\]]/g, '\\$&');
-        const url = this.content.fields.videoUrl;
-        const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
-        const results = regex.exec(url);
-
-        if (!results) {
-          return null;
-        }
-        if (!results[2]) {
-          return '';
-        }
-
-        return decodeURIComponent(results[2].replace(/\+/g, ' '));
       },
     },
 

--- a/components/_Global.vue
+++ b/components/_Global.vue
@@ -221,6 +221,27 @@
         // flip our bit.
         this.formatTimestamps = !this.formatTimestamps;
       },
+
+      // Parse URL parameters
+      //
+      // Since IE11+node don't support URLSearchParams
+      //
+      // @see https://stackoverflow.com/a/901144
+      // @see https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility
+      parseQueryParams(url, name) {
+        name = name.replace(/[\[\]]/g, '\\$&');
+        const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)');
+        const results = regex.exec(url);
+
+        if (!results) {
+          return null;
+        }
+        if (!results[2]) {
+          return '';
+        }
+
+        return decodeURIComponent(results[2].replace(/\+/g, ' '));
+      },
     },
   }
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",

--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -73,12 +73,20 @@
         return this.isVideoCard ? 'player' : 'summary_large_image';
       },
 
+      ogType() {
+        return this.isVideoCard ? 'video:other': 'article';
+      },
+
       socialVideoSlug() {
         return this.isVideoCard ? this.parseQueryParams(this.entry.fields.videoUrl, 'v') : 'NO-SLUG-FOUND';
       },
 
       socialVideoUrl() {
-        return this.isVideoCard ? `https://www.youtube-nocookie.com/embed/${this.socialVideoSlug}?autoplay=0&rel=0&controls=1&showinfo=0` : '';
+        return this.isVideoCard ? `https://www.youtube-nocookie.com/embed/${this.socialVideoSlug}?html5=1&autoplay=0&rel=0&controls=1&showinfo=0` : '';
+      },
+
+      socialVideoType() {
+        return this.isVideoCard ? 'video/mp4' : '';
       },
 
       socialVideoWidth() {
@@ -303,7 +311,7 @@
 
           // Facebook specific
           { hid: 'fb-app-id', property: 'fb:app_id', content: process.env.fbAppId },
-          { hid: 'og-type', property: 'og:type', content: 'article' },
+          { hid: 'og-type', property: 'og:type', content: this.ogType },
           { hid: 'og-locale', property: 'og:locale', content: this.parents[0].fields.language },
           { hid: 'og-url', property: 'og:url', content: `${process.env.baseUrl}/${this.parents[0].fields.language}/country/${this.parents[0].fields.slug}/card/${this.sysIdShort}/` },
           { hid: 'og-title', property: 'og:title', content: this.officeName },
@@ -312,6 +320,11 @@
           { hid: 'og-image-type', property: 'og:image:type', content: this.socialImageType },
           { hid: 'og-image-width', property: 'og:image:width', content: this.socialImageWidth },
           { hid: 'og-image-height', property: 'og:image:height', content: this.socialImageHeight },
+          { hid: 'og-video', property: 'og:video', content: this.socialVideoUrl },
+          { hid: 'og-video-secure-url', property: 'og:video:secure_url', content: this.socialVideoUrl },
+          { hid: 'og-video-type', property: 'og:video:type', content: this.socialVideoType },
+          { hid: 'og-video-w', property: 'og:video:width', content: this.socialVideoWidth },
+          { hid: 'og-video-h', property: 'og:video:height', content: this.socialVideoHeight },
         ],
       };
     },

--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -78,7 +78,7 @@
       },
 
       socialVideoUrl() {
-        return this.isVideoCard ? `https://www.youtube-nocookie.com/embed/${this.socialVideoSlug}?autoplay=1&rel=0&controls=0&showinfo=0` : '';
+        return this.isVideoCard ? `https://www.youtube-nocookie.com/embed/${this.socialVideoSlug}?autoplay=0&rel=0&controls=1&showinfo=0` : '';
       },
 
       socialVideoWidth() {


### PR DESCRIPTION
# DSR-289

This is a follow-up to the initial social work, which provides much better integration for Videos on social media.

Twitter and FB were implemented, and both networks should render playable video embeds when sharing the respective Card URLs. Other card types are unaffected.