### PR TITLE
DSR-320: set correct value for og:type on Video cards

### DIFF
--- a/pages/_lang/country/_slug/card/_sysid.vue
+++ b/pages/_lang/country/_slug/card/_sysid.vue
@@ -74,7 +74,7 @@
       },
 
       ogType() {
-        return this.isVideoCard ? 'video:other': 'article';
+        return this.isVideoCard ? 'video.other': 'article';
       },
 
       socialVideoSlug() {


### PR DESCRIPTION
# DSR-320

I made a typo in the FB OG tag for Video cards. Frustratingly, I am unable to do local testing using ngrok to confirm the fix. But I think it will work now.