### PR TITLE
DSR-267: CardFooter now says 'Downloaded'

### DIFF
--- a/components/CardFooter.vue
+++ b/components/CardFooter.vue
@@ -5,7 +5,7 @@
       <span dir="ltr">{{ thisUrl }}</span>
     </p>
     <p class="date">
-      <span class="label">{{ $t('Date', locale) }}:</span>
+      <span class="label">{{ $t('Downloaded', locale) }}:</span>
       <time :datetime="this.today">{{ this.todayFormatted }}</time>
     </p>
   </footer>


### PR DESCRIPTION
# DSR-267

Our work in DSR-294 means it shows an absolute timestamp at the top of all PDF/PNGs. The 'Date'
label was already confusing and became more so. Fixing the PNG to say 'Downloaded' makes it clear why the dates are different. It also matches what PDFs were already doing.