### PR TITLE
DSR-329: don't lazy load images on Snap PDFs/PNGs

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -46,7 +46,7 @@
 
             <img
               class="article__img"
-              loading="lazy"
+              :loading="this.$store.state.globalFormatting.imgLoading"
               lazyload="1"
               :src="`${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}`"
               :alt="content.fields.image.fields.title">

--- a/components/FlashUpdate.vue
+++ b/components/FlashUpdate.vue
@@ -50,7 +50,7 @@
 
             <img
               class="article__img"
-              loading="lazy"
+              :loading="this.$store.state.globalFormatting.imgLoading"
               lazyload="1"
               :src="`${secureImageUrl}?w=413&h=${getImageHeight(413, content.fields.image)}`"
               :alt="content.fields.image.fields.title">

--- a/components/Interactive.vue
+++ b/components/Interactive.vue
@@ -51,7 +51,7 @@
 
             <img
               class="interactive__img"
-              loading="lazy"
+              :loading="this.$store.state.globalFormatting.imgLoading"
               lazyload="1"
               :src="`${secureImageUrl}?w=1048&h=${getImageHeight(1048, content.fields.image)}`"
               :alt="content.fields.image.fields.title">

--- a/components/KeyMessages.vue
+++ b/components/KeyMessages.vue
@@ -47,7 +47,7 @@
             <img
               :src="`${secureImageUrl}?w=1032&h=${getImageHeight(1032, image)}`"
               :alt="image.fields.title"
-              loading="auto"
+              loading="eager"
             >
           </picture>
           <figcaption v-if="image.fields.description">{{ image.fields.description }}</figcaption>

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -28,8 +28,7 @@
           class="video__container">
           <img
             class="video__img"
-            loading="lazy"
-            lazyload="1"
+            loading="eager"
             :src="videoEmbedPreview"
             :alt="`Preview of ${videoEmbedLink}`">
           <button class="video__play"></button>

--- a/components/Visual.vue
+++ b/components/Visual.vue
@@ -41,7 +41,7 @@
 
           <img
             class="visual__img"
-            loading="lazy"
+            :loading="this.$store.state.globalFormatting.imgLoading"
             lazyload="1"
             :src="`${secureImageUrl}?w=1048&h=${getImageHeight(1048, content.fields.image)}`"
             :alt="content.fields.image.fields.title">

--- a/components/_Page.vue
+++ b/components/_Page.vue
@@ -27,11 +27,8 @@
         // Configure MutationOberver
         const mutationConfig = {attributes: true};
 
-        // Store `this` in a variable to access within MutationObserver.
-        const page = this;
-
         // Callback when Snap class is detected
-        const mutationCallback = function(mutationsList, oberver) {
+        const mutationCallback = (mutationsList, oberver) => {
           for (let mutation of mutationsList) {
             if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
               if (mutation.target.className.indexOf('snap') !== -1) {
@@ -39,7 +36,7 @@
                 // the Vuex store. In theory this is a short-lived page-view that
                 // only gets triggered by Snap Service so the app doesn't provide
                 // a way to "undo" the change we're making here.
-                page.$store.commit('SET_GLOBAL_TIMESTAMP_FORMATTING', false);
+                this.$store.commit('SET_GLOBAL_TIMESTAMP_FORMATTING', false);
               }
             }
           }

--- a/components/_Page.vue
+++ b/components/_Page.vue
@@ -31,16 +31,22 @@
         const mutationCallback = (mutationsList, oberver) => {
           for (let mutation of mutationsList) {
             if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+              // The classname implies that this is a short-lived page-view which
+              // only gets triggered by Snap Service so the app doesn't provide
+              // a way to "undo" the changes we're making here.
               if (mutation.target.className.indexOf('snap') !== -1) {
                 // Disable timestamp formatting *for the entire page* by updating
-                // the Vuex store. In theory this is a short-lived page-view that
-                // only gets triggered by Snap Service so the app doesn't provide
-                // a way to "undo" the change we're making here.
-                this.$store.commit('SET_GLOBAL_TIMESTAMP_FORMATTING', false);
+                // the Vuex store.
+                this.$store.commit('SET_GLOBAL_FORMATTING_TIMESTAMP', false);
+
+                // Additionally, set all images which we potentially marked for
+                // lazy-loading to be eagerly loaded, so that PDFs contain all
+                // expected media.
+                this.$store.commit('SET_GLOBAL_FORMATTING_IMGLOADING', 'eager');
               }
             }
           }
-        }
+        };
 
         // Create MutationOberver
         const observer = new MutationObserver(mutationCallback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",

--- a/store/index.js
+++ b/store/index.js
@@ -120,9 +120,10 @@ export const state = () => ({
   },
 
   // Lets the whole app render dates consistently when context requires it.
-  // e.g. Used by Snaps to render PDF/PNGs with absolute dates.
+  // e.g. Used by Snaps to render PDF/PNGs.
   globalFormatting: {
     formatTimestamps: 'auto',
+    imgLoading: 'lazy',
   },
 });
 
@@ -148,7 +149,11 @@ export const mutations = {
     }
   },
 
-  SET_GLOBAL_TIMESTAMP_FORMATTING(state, setting) {
+  SET_GLOBAL_FORMATTING_TIMESTAMP(state, setting) {
     state.globalFormatting.formatTimestamps = setting;
+  },
+
+  SET_GLOBAL_FORMATTING_IMGLOADING(state, setting) {
+    state.globalFormatting.imgLoading = setting;
   },
 };


### PR DESCRIPTION
# DSR-329

while fantastic for mobile devices, our native lazy-loading broke really long PDFs that contain numerous graphics far below the infamous fold. I've tweaked the logic to allow global overriding and set up our Mutation Observer to flip a switch when it detects that Snap is taking a PDF/PNG.