### PR TITLE
DSR-337: regional office code

### DIFF
--- a/_tests/unit/AppHeader.spec.js
+++ b/_tests/unit/AppHeader.spec.js
@@ -1,0 +1,212 @@
+import { mount } from '@vue/test-utils';
+import AppHeader from '~/components/AppHeader.vue';
+
+describe('AppHeader', () => {
+  let wrapper;
+  let propsData = {
+    title: 'Unit Title',
+    subtitle: 'Unit Subtitle',
+  };
+  let mocks = {
+    $store: {
+      state: {
+        locale: 'un',
+        locales: [
+          {
+            code: 'en',
+            name: 'English',
+            dir: 'ltr',
+            display: true,
+            fallback: 'en',
+          },
+          {
+            code: 'un',
+            name: 'Unitese',
+            dir: 'ltr',
+            display: false,
+            fallback: 'en',
+          },
+        ],
+        globalFormatting: {
+          formatTimestamps: true,
+        },
+        reportMeta: {
+          language: 'un',
+        },
+      },
+      commit: jest.fn(),
+    },
+    $i18n: {
+      path (path) {
+        return '/unit/' + path;
+      },
+    },
+    $moment() {
+      return {
+        diff() {
+          return 'unit days ago';
+        },
+        format() {
+          return 'unit format';
+        },
+        locale() {
+          return {
+            format() {
+              return 'unit localized';
+            },
+          };
+        },
+      };
+    },
+    $route: {
+      path: '/en/country/unit',
+    },
+    $t (str) {
+      return str;
+    },
+  };
+
+  // For wrapper.vm.envClass
+  delete window.location;
+  window.location = new URL('https://dev.reports-unocha-org.ahconu.org');
+  const fakeWindowLocationHref = 'https%3A%2F%2Fdev.reports-unocha-org.ahconu.org%2F';
+
+  beforeEach(() => {
+    wrapper = mount(AppHeader, {
+      propsData,
+      mocks,
+      stubs: [
+        'nuxt-link',
+        'client-only',
+      ],
+    });
+  });
+
+  it('should render the component', () => {
+    expect(wrapper.find('img.logo').html()).toContain('UN Office for the Coordination of Humanitarian Affairs');
+  });
+
+  it('should toggle Share when prompted', () => {
+    wrapper.vm.toggleShare();
+    expect(wrapper.vm.shareIsOpen).toBe(true);
+    wrapper.vm.toggleShare();
+    expect(wrapper.vm.shareIsOpen).toBe(false);
+  });
+
+  it('should open Share when prompted', () => {
+    wrapper.vm.openShare();
+    expect(wrapper.vm.shareIsOpen).toBe(true);
+  });
+
+  it('should close Share when prompted', () => {
+    wrapper.vm.openShare();
+    expect(wrapper.vm.shareIsOpen).toBe(true);
+    wrapper.vm.closeShare();
+    expect(wrapper.vm.shareIsOpen).toBe(false);
+  });
+
+  it('should maintain language-free URL context for localization', () => {
+    expect(wrapper.vm.urlContext).toBe('country/unit');
+  });
+
+  it('should produce the current, localized date using moment.js', () => {
+    expect(wrapper.vm.today).toContain('unit localized');
+  });
+
+  it('should set an environment class when necessary', async () => {
+    expect(wrapper.vm.envClass).toBe('dev');
+    expect(wrapper.find('.env').html()).toContain('viewing the <strong>dev</strong> Environment');
+
+    // TODO: cover the demo-format URL.
+  });
+
+  it('should use custom set of translations when necessary', async () => {
+    wrapper.setProps({
+      translations: [
+        {
+          code: 'en',
+          name: 'English',
+          dir: 'ltr',
+          display: true,
+          fallback: 'en',
+        },
+        {
+          code: 'un',
+          name: 'Unitese',
+          dir: 'ltr',
+          display: true,
+          fallback: 'en',
+        }
+      ],
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.lang-switcher').html()).toContain('/en/country/unit');
+    expect(wrapper.find('.lang-switcher').html()).toContain('/un/country/unit');
+  });
+
+  it('should show custom Archive link when supplied', () => {
+    wrapper.setData({
+      customArchive: 'https://example.com',
+    });
+    expect(wrapper.vm.archiveLink).toBe('https://example.com');
+  });
+
+  it('should show standard Archive link when countryCode is valid', () => {
+    wrapper.setProps({
+      countrycode: 'uno',
+    });
+    expect(wrapper.vm.archiveLink).toContain('iso3:uno');
+  });
+
+  it('should show no Archive link when countryCode is valid', () => {
+    wrapper.setProps({
+      countrycode: 'ro1',
+    });
+    expect(wrapper.vm.archiveLink).toBe('');
+  });
+
+  it('should show no Archive link when neither is supplied', () => {
+    wrapper.setData({
+      customArchive: '',
+    });
+    wrapper.setProps({
+      countrycode: '',
+    });
+    expect(wrapper.vm.archiveLink).toBe('');
+  });
+
+  it('should generate a Share message', () => {
+    expect(wrapper.vm.shareMessage).toContain('Read the latest from Unit');
+  });
+
+  it('should generate a Share base URL on the client', () => {
+    expect(wrapper.vm.shareBaseUrl).toContain('dev.reports-unocha-org.ahconu.org');
+  });
+
+  // it('should generate a Share base URL on the server', () => {
+  //   // This can apparently be done in a separate file using a docblock but
+  //   // the first attempt yielded other issues mounting components, which
+  //   // expect to be in a browser environment. For now, a TODO.
+  //   //
+  //   // @see https://stackoverflow.com/a/48691959
+  // });
+
+  it('should generate a share URL for Facebook', () => {
+    expect(wrapper.vm.shareUrlFacebook).toContain('facebook.com/sharer/sharer.php?u=' + fakeWindowLocationHref);
+  });
+
+  it('should generate a share URL for Twitter', () => {
+    expect(wrapper.vm.shareUrlTwitter).toContain('twitter.com/intent/tweet?text=');
+    expect(wrapper.vm.shareUrlTwitter).toContain(fakeWindowLocationHref);
+  });
+
+  it('should generate a share URL for Email', () => {
+    expect(wrapper.vm.shareUrlEmail).toContain('mailto:');
+    expect(wrapper.vm.shareUrlEmail).toContain('Situation Report: Unit Title');
+    expect(wrapper.vm.shareUrlEmail).toContain(fakeWindowLocationHref);
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+});

--- a/_tests/unit/Video.spec.js
+++ b/_tests/unit/Video.spec.js
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils';
+import Video from '~/components/Video.vue';
+
+describe('Video', () => {
+  let wrapper;
+  let mocks = {
+    $store: {
+      state: {
+        locale: 'un',
+        locales: [
+          {
+            code: 'un',
+            name: 'Unitese',
+            dir: 'ltr',
+            display: false,
+            fallback: 'en',
+          },
+        ],
+        globalFormatting: {
+          formatTimestamps: true,
+        },
+        reportMeta: {
+          language: 'un',
+        },
+      },
+      commit: jest.fn(),
+    },
+    $i18n: {
+      path (path) {
+        return '/unit/' + path;
+      },
+    },
+    $moment() {
+      return {
+        diff() {
+          return 'unit days ago';
+        },
+        format() {
+          return 'unit format';
+        },
+        locale() {
+          return {
+            format() {
+              return 'unit localized';
+            },
+          };
+        },
+      };
+    },
+    $t (str) {
+      return str;
+    },
+  };
+
+  beforeEach(() => {
+    wrapper = mount(Video, {
+      propsData: {
+        content: {
+          sys: {
+            id: 'unit1',
+          },
+          fields: {
+            videoUrl: 'https://www.youtube.com/watch?v=ScMzIvxBSi4',
+            description: {},
+          },
+        },
+        options: {
+          newWindow: true,
+        },
+      },
+      mocks,
+      stubs: [
+        'nuxt-link',
+        'client-only',
+      ],
+    });
+  });
+
+  it('should render the component', () => {
+    expect(wrapper.find('.video__embed').html()).toContain('<a data-video-slug');
+  });
+
+  it('should have a CSS ID matching CTF payload', () => {
+    expect(wrapper.vm.cssIdSelector).toBe('#cf-unit1');
+  });
+
+  it('should render a link to Video', () => {
+    expect(wrapper.vm.videoEmbedSrc).toBe(`https://www.youtube-nocookie.com/embed/ScMzIvxBSi4?autoplay=1&rel=0&controls=0&showinfo=0`);
+  });
+
+  it('should process video when prompted', () => {
+    expect(wrapper.vm.videoProcessed).toBe(false);
+    wrapper.vm.processVideo();
+    expect(wrapper.vm.videoProcessed).toBe(true);
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+});

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -16,7 +16,7 @@
         <span class="subtitle" v-else aria-hidden="true">&nbsp;</span>
 
         <span class="last-updated" v-if="updated">{{ $t('Last updated', locale) }}: <time :datetime="updated">{{ $moment(updated).locale(localeOrFallback).format('D MMM YYYY') }}</time></span>
-        <span class="past-sitreps" v-if="countrycode || customArchive"><a :href="archiveLink" target="_blank" rel="noopener">({{ $t('Archive', locale) }})</a></span>
+        <span class="past-sitreps" v-if="!!archiveLink"><a :href="archiveLink" target="_blank" rel="noopener">({{ $t('Archive', locale) }})</a></span>
       </div>
     </div>
 
@@ -176,14 +176,14 @@
       },
 
       archiveLink() {
-        let archiveLink;
+        let archiveLink = '';
 
         // When a custom link is provided, use its value.
         if (this.customArchive) {
           archiveLink = this.customArchive;
-        }
-        else {
-          // By default we use `countryCode` to create the archive link
+        } else if (this.countrycode && !this.countrycode.match(/^ro[1-9]$/)) {
+          // All countryCode values besides RO[1-9] can be formatted into the
+          // standard Archive link format.
           archiveLink = `https://reliefweb.int/updates?search=primary_country.iso3:${this.countrycode} AND ocha_product:("Humanitarian Bulletin" OR "Situation Report" OR "Flash Update") AND source:OCHA#content`;
         }
 

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -48,7 +48,7 @@
         />
         <div v-if="share" class="share" :class="{ 'share--is-open': shareIsOpen }">
           <client-only>
-            <button class="share__toggle" @click="toggleShare" @touchend="click" v-on-clickaway="closeShare">
+            <button class="share__toggle" @click.prevent="toggleShare" @touchend.prevent="toggleShare" v-on-clickaway="closeShare">
               <span class="element-invisible">{{ $t('Share', locale) }}</span>
             </button>
             <div class="share__options card">
@@ -107,14 +107,6 @@
     },
 
     methods: {
-      click(ev) {
-        // In order to normalize touch events, we trigger the click handler
-        // immediately and stop event propagation.
-        this.toggleShare();
-        ev.stopPropagation();
-        ev.preventDefault();
-      },
-
       toggleShare() {
         this.shareIsOpen = !this.shareIsOpen;
       },
@@ -191,7 +183,9 @@
       },
 
       shareBaseUrl() {
-        return typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : `${process.env.baseUrl}${this.$route.path}`;
+        return typeof window !== 'undefined'
+          ? encodeURIComponent(window.location.href)
+          : `${process.env.baseUrl}${this.$route.path}`;
       },
 
       shareMessage() {

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -20,7 +20,7 @@
           allowfullscreen="allowfullscreen"></iframe>
         <a
           v-else
-          @click="processVideo"
+          @click.prevent="processVideo"
           :data-video-slug="videoSlug"
           :href="videoEmbedLink"
           target="_blank"
@@ -105,10 +105,7 @@
     },
 
     methods: {
-      processVideo(ev) {
-        ev.stopPropagation();
-        ev.preventDefault();
-
+      processVideo() {
         this.videoProcessed = true;
       },
     },

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -179,7 +179,7 @@
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
-    background: transparent url('/ui/button-youtube.png') no-repeat;
+    background: transparent url('/assets/ui/button-youtube.png') no-repeat;
     background-size: contain;
     cursor: pointer;
     transition: transform .08333s ease-in-out;


### PR DESCRIPTION
# DSR-337

We are setting up a custom format for Regional Offices to have country codes. They follow a pattern `/RO[1-9]/` to allow for up to nine regional offices. The number being present will also prevent the possibility of a new ISO3 ever overlapping with these custom codes.

The work in this branch is to prevent the auto-generated Archive link from appearing when these codes are used. Since they're not real ISO3 we can't link to RW using that code.

I also noticed that youtube buttons weren't showing. It's a fairly old regression but we only deployed it two weeks ago. At least it's fixed now.