### PR TITLE
chore(release): 2.10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.10.13](https://github.com/UN-OCHA/reports-site/compare/v2.10.12...v2.10.13) (2024-02-07)
+
+### Bug Fixes
+
+* drop FTS 2020/2021, add FTS 2024 ([6eecd17](https://github.com/UN-OCHA/reports-site/commit/6eecd173b2e16be0b03474ea2e4547250554f08f))
+
+
 ## [2.10.12](https://github.com/UN-OCHA/reports-site/compare/v2.10.11...v2.10.12) (2023-10-17)
 
 * **security:** upgrade to node.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-site",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Digital Situation Reports",
   "license": "Apache-2.0",
   "author": "UNOCHA",


### PR DESCRIPTION
## [2.10.13](https://github.com/UN-OCHA/reports-site/compare/v2.10.12...v2.10.13) (2024-02-07)

### Bug Fixes

* drop FTS 2020/2021, add FTS 2024 ([6eecd17](https://github.com/UN-OCHA/reports-site/commit/6eecd173b2e16be0b03474ea2e4547250554f08f))
